### PR TITLE
Fix audio imports

### DIFF
--- a/src/pages/Timer/ProgrammTimer.vue
+++ b/src/pages/Timer/ProgrammTimer.vue
@@ -198,6 +198,12 @@
 import MY_ITEM_BTN from 'components/MyItemBtn.vue'
 import getRandomCitation from 'src/tools/citate.js'
 import { useAppStore } from 'stores/appStore'
+import createSoundMap from 'src/tools/soundMap.js'
+import beepbeepbeep_1s from 'assets/sounds/beepbeepbeep_1s.wav'
+import beep_1s from 'assets/sounds/beep_1s.wav'
+import tada from 'assets/sounds/tada.wav'
+
+const soundMap = createSoundMap({ beepbeepbeep_1s, beep_1s, tada })
 
 export default {
   name: 'ProgrammTimer',
@@ -530,7 +536,7 @@ export default {
         myMedia.play()
         return
       } else {
-        var audio = new Audio(require(`assets/sounds/${item}.wav`))
+        var audio = new Audio(soundMap[item])
         audio.play({ playAudioWhenScreenIsLocked: true })
         return
       }

--- a/src/pages/Timer/QuickTimer.vue
+++ b/src/pages/Timer/QuickTimer.vue
@@ -47,6 +47,10 @@
 
 <script>
 import { useAppStore } from 'stores/appStore'
+import createSoundMap from 'src/tools/soundMap.js'
+import gong from 'assets/sounds/gong.wav'
+
+const soundMap = createSoundMap({ gong })
 export default {
   name: 'QuickTimer',
   components: {
@@ -146,7 +150,7 @@ export default {
         myMedia.play()
         return
       } else {
-        var audio = new Audio(require(`assets/sounds/${item}.wav`))
+        var audio = new Audio(soundMap[item])
         audio.play({ playAudioWhenScreenIsLocked: true })
         return
       }

--- a/src/tools/soundMap.js
+++ b/src/tools/soundMap.js
@@ -1,0 +1,3 @@
+export default function createSoundMap(sounds) {
+  return sounds
+}


### PR DESCRIPTION
## Summary
- map sound names to imported audio files
- use explicit audio imports in QuickTimer
- use explicit audio imports in ProgramTimer

## Testing
- `npm run lint` *(fails: vue/multi-word-component-names)*

------
https://chatgpt.com/codex/tasks/task_e_6873829525948322a6a87ee612284a76