### PR TITLE
Add shared sound helper

### DIFF
--- a/src/pages/Timer/ProgrammTimer.vue
+++ b/src/pages/Timer/ProgrammTimer.vue
@@ -198,12 +198,7 @@
 import MY_ITEM_BTN from 'components/MyItemBtn.vue'
 import getRandomCitation from 'src/tools/citate.js'
 import { useAppStore } from 'stores/appStore'
-import createSoundMap from 'src/tools/soundMap.js'
-import beepbeepbeep_1s from 'assets/sounds/beepbeepbeep_1s.wav'
-import beep_1s from 'assets/sounds/beep_1s.wav'
-import tada from 'assets/sounds/tada.wav'
-
-const soundMap = createSoundMap({ beepbeepbeep_1s, beep_1s, tada })
+import playSound from 'src/tools/sound.js'
 
 export default {
   name: 'ProgrammTimer',
@@ -430,7 +425,7 @@ export default {
       this.TIME_DATA = this._prepareTimer() // prepare an array with the times
       this.interval = true
       // COUNT DOWN 1s
-      this.playSound('beepbeepbeep_1s')
+      playSound('beepbeepbeep_1s', this.store.settings.audio_playback)
       await this.delay(1500)
 
       this.store.setLastPreset(JSON.parse(JSON.stringify(this.localData)))
@@ -450,7 +445,7 @@ export default {
       if (this.TIME_IND === -1) {
         this.timer_finished = true
         this.value = 0
-        this.playSound('tada')
+        playSound('tada', this.store.settings.audio_playback)
         return
       } // else
 
@@ -460,7 +455,7 @@ export default {
       // now start the intervall with ticks of 1s
       this.interval = setInterval(() => {
         // check if timer is finished
-        if (this.value + 1 === nextTimer.value) this.playSound('beep_1s')
+        if (this.value + 1 === nextTimer.value) playSound('beep_1s', this.store.settings.audio_playback)
         if (this.value >= nextTimer.value) {
 
           // set _check to true
@@ -517,30 +512,6 @@ export default {
     },
 
 
-    // SOUNDS
-    playSound(item) {
-      if (!this.store.settings.audio_playback) return
-      if (this.$q.platform.is.cordova) {
-        var path = cordova.file.applicationDirectory + "www/media/" + item + ".wav";
-
-        var myMedia = new Media(path,
-          function () {
-            console.log("Audio Success");
-          },
-          function (err) {
-            console.log("Audio Error: " + err.code);
-          }
-        );
-
-
-        myMedia.play()
-        return
-      } else {
-        var audio = new Audio(soundMap[item])
-        audio.play({ playAudioWhenScreenIsLocked: true })
-        return
-      }
-    },
 
     // SOME HELPER
 

--- a/src/pages/Timer/QuickTimer.vue
+++ b/src/pages/Timer/QuickTimer.vue
@@ -47,10 +47,7 @@
 
 <script>
 import { useAppStore } from 'stores/appStore'
-import createSoundMap from 'src/tools/soundMap.js'
-import gong from 'assets/sounds/gong.wav'
-
-const soundMap = createSoundMap({ gong })
+import playSound from 'src/tools/sound.js'
 export default {
   name: 'QuickTimer',
   components: {
@@ -103,7 +100,7 @@ export default {
       // value is the actual value of the timer
       // time is the time in seconds
       // timeLeft is the time left in seconds
-      this.playSound('gong')
+      playSound('gong', this.store.settings.audio_playback)
       this.timer_finished = false
       let timeLeft = this.time
       this.value = 0
@@ -113,7 +110,7 @@ export default {
         timeLeft = timeLeft - 1
         this.value = value
         if (timeLeft <= 0) {
-          this.playSound('gong')
+          playSound('gong', this.store.settings.audio_playback)
           clearInterval(this.interval)
           this.interval = undefined
           this.value = 0
@@ -129,31 +126,6 @@ export default {
       this.interval = undefined
       this.value = 0
       this.timer_finished = false
-    },
-
-    // PLAY SOUND FILE
-    playSound(item) {
-      if (!this.store.settings.audio_playback) return
-      if (this.$q.platform.is.cordova) {
-        var path = cordova.file.applicationDirectory + "www/media/" + item + ".wav";
-
-        var myMedia = new Media(path,
-          function () {
-            console.log("Audio Success");
-          },
-          function (err) {
-            console.log("Audio Error: " + err.code);
-          }
-        );
-
-
-        myMedia.play()
-        return
-      } else {
-        var audio = new Audio(soundMap[item])
-        audio.play({ playAudioWhenScreenIsLocked: true })
-        return
-      }
     }
 
 

--- a/src/tools/sound.js
+++ b/src/tools/sound.js
@@ -1,0 +1,26 @@
+import { Platform } from 'quasar'
+import createSoundMap from './soundMap.js'
+import gong from 'assets/sounds/gong.wav'
+import beepbeepbeep_1s from 'assets/sounds/beepbeepbeep_1s.wav'
+import beep_1s from 'assets/sounds/beep_1s.wav'
+import tada from 'assets/sounds/tada.wav'
+
+const soundMap = createSoundMap({ gong, beepbeepbeep_1s, beep_1s, tada })
+
+export default function playSound (name, enabled = true) {
+  if (!enabled) return
+
+  if (Platform.is.cordova) {
+    const path = cordova.file.applicationDirectory + 'www/media/' + name + '.wav'
+    const myMedia = new Media(
+      path,
+      function () { console.log('Audio Success') },
+      function (err) { console.log('Audio Error: ' + err.code) }
+    )
+    myMedia.play()
+    return
+  }
+
+  const audio = new Audio(soundMap[name])
+  audio.play({ playAudioWhenScreenIsLocked: true })
+}


### PR DESCRIPTION
## Summary
- create `src/tools/sound.js` with platform aware `playSound`
- use the helper in QuickTimer and ProgramTimer

## Testing
- `npx eslint src/tools/sound.js src/pages/Timer/QuickTimer.vue src/pages/Timer/ProgrammTimer.vue`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6873a12738dc83228935ae8687040293