### PR TITLE
Implement timer composable and refactor pages

### DIFF
--- a/src/composables/useTimer.js
+++ b/src/composables/useTimer.js
@@ -1,0 +1,36 @@
+import { ref, computed, onUnmounted } from 'vue'
+
+export default function useTimer () {
+  const interval = ref(null)
+  const progress = ref(0)
+  const isActive = computed(() => interval.value !== null)
+
+  function start (callback, delay = 1000) {
+    stop()
+    interval.value = setInterval(() => {
+      progress.value += 1
+      if (typeof callback === 'function') {
+        callback(progress.value)
+      }
+    }, delay)
+  }
+
+  function stop (reset = true) {
+    if (interval.value) {
+      clearInterval(interval.value)
+      interval.value = null
+    }
+    if (reset) {
+      progress.value = 0
+    }
+  }
+
+  onUnmounted(stop)
+
+  return {
+    start,
+    stop,
+    progress,
+    isActive
+  }
+}


### PR DESCRIPTION
## Summary
- add `useTimer` composable managing intervals and progress
- refactor QuickTimer and ProgrammTimer pages to use the composable
- replace duplicated timer handling logic

## Testing
- `npm run lint` *(fails: vue multi-word component name rule in archived files)*
- `npm run test:unit` *(fails: test suite errors)*


------
https://chatgpt.com/codex/tasks/task_e_6873a2c8ce1c83228e65de7511787afb