### PR TITLE
Migrate to flat eslint config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,5 @@
 /node_modules
 .eslintrc.js
 babel.config.js
+
+ARCHIVE

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,49 @@
+import { fileURLToPath } from 'url';
+import path from 'path';
+import { FlatCompat } from '@eslint/eslintrc';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+const [config] = compat.config({
+  root: true,
+  parserOptions: {
+    parser: '@babel/eslint-parser',
+    ecmaVersion: 2018,
+    sourceType: 'module'
+  },
+  env: {
+    browser: true,
+    'vue/setup-compiler-macros': true
+  },
+  extends: ['plugin:vue/vue3-essential', 'prettier'],
+  plugins: ['vue'],
+  globals: {
+    ga: 'readonly',
+    cordova: 'readonly',
+    __statics: 'readonly',
+    __QUASAR_SSR__: 'readonly',
+    __QUASAR_SSR_SERVER__: 'readonly',
+    __QUASAR_SSR_CLIENT__: 'readonly',
+    __QUASAR_SSR_PWA__: 'readonly',
+    process: 'readonly',
+    Capacitor: 'readonly',
+    chrome: 'readonly'
+  },
+  ignorePatterns: [
+    'dist',
+    'src-bex/www',
+    'src-capacitor',
+    'src-cordova',
+    '.quasar',
+    'node_modules',
+    '.eslintrc.js',
+    'babel.config.js',
+    'ARCHIVE'
+  ],
+  rules: {
+    'prefer-promise-reject-errors': 'off',
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
+  }
+});
+export default [config];

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build_ios": "quasar build -m ios --ide",
     "icon": "icongenie generate -i ./public/logo_de.png",
     "icon_cordova": "icongenie generate -m cordova -i ./public/logo_de.png",
-    "lint": "eslint --ext .js,.vue ./",
+    "lint": "eslint .",
     "format": "prettier --write \"**/*.{js,vue,scss,html,md,json}\" --ignore-path .gitignore",
     "test": "echo \"See package.json => scripts for available tests.\" && exit 0",
     "test:unit": "jest --updateSnapshot",


### PR DESCRIPTION
## Summary
- add `eslint.config.js` with FlatCompat
- update lint script for new ESLint
- ignore archived sources during linting

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6873ae3069e8832282538ccffe9623a3