### PR TITLE
Add timer unit tests

### DIFF
--- a/test/jest/__tests__/MyButton.spec.js
+++ b/test/jest/__tests__/MyButton.spec.js
@@ -5,7 +5,7 @@ import { QBtn } from 'quasar';
 import MyButton from './demo/MyButton';
 
 // Specify here Quasar config you'll need to test your component
-installQuasarPlugin();
+installQuasarPlugin({ components: { QBtn } });
 
 describe('MyButton', () => {
   it('has increment method', () => {

--- a/test/jest/__tests__/MyDialog.spec.js
+++ b/test/jest/__tests__/MyDialog.spec.js
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
 import { DOMWrapper, mount } from '@vue/test-utils';
+import { QDialog, QCard, QCardSection } from 'quasar';
 import MyDialog from './demo/MyDialog';
 
-installQuasarPlugin();
+installQuasarPlugin({ components: { QDialog, QCard, QCardSection } });
 
 describe('MyDialog', () => {
   let wrapper;

--- a/test/jest/__tests__/ProgramTimer.spec.js
+++ b/test/jest/__tests__/ProgramTimer.spec.js
@@ -1,0 +1,68 @@
+import { beforeEach, afterEach, describe, it, expect, jest } from '@jest/globals'
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest'
+import { shallowMount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+jest.mock('src/tools/sound.js', () => ({ __esModule: true, default: jest.fn() }))
+import ProgramTimer from 'pages/Timer/ProgrammTimer.vue'
+import { useAppStore } from 'stores/appStore'
+
+installQuasarPlugin()
+
+describe('ProgramTimer', () => {
+  let wrapper
+  let store
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    store = useAppStore()
+    store.addProgramStep({ type: 'action', duration: 1, repetitions: 1 })
+    wrapper = shallowMount(ProgramTimer, {
+      global: {
+        plugins: [pinia],
+        mocks: { $router: { go: jest.fn() } },
+        stubs: {
+          'q-page': true,
+          'q-btn': true,
+          'q-chip': true,
+          'q-list': true,
+          'q-item': true,
+          'q-item-section': true,
+          'q-btn-dropdown': true,
+          'q-popup-proxy': true,
+          'q-card': true,
+          'q-card-section': true,
+          'q-slider': true,
+          'q-select': true,
+          'q-input': true,
+          'q-tooltip': true,
+          'q-separator': true,
+          'q-icon': true,
+          'q-knob': true
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('runs program and resets progress when finished', () => {
+    wrapper.vm.TIME_DATA = wrapper.vm._prepareTimer()
+    wrapper.vm.nextTimer()
+    jest.advanceTimersByTime(1000)
+    expect(wrapper.vm.timer_finished).toBe(true)
+    expect(wrapper.vm.progress).toBe(0)
+  })
+
+  it('stopTimer halts timer and resets progress', () => {
+    wrapper.vm.startTimer()
+    jest.advanceTimersByTime(1500)
+    jest.advanceTimersByTime(500)
+    wrapper.vm.stopTimer()
+    expect(wrapper.vm.timer_halted).toBe(true)
+    expect(wrapper.vm.progress).toBe(0)
+  })
+})

--- a/test/jest/__tests__/QuickTimer.spec.js
+++ b/test/jest/__tests__/QuickTimer.spec.js
@@ -1,0 +1,59 @@
+import { beforeEach, afterEach, describe, it, expect, jest } from '@jest/globals'
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest'
+import { shallowMount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+jest.mock('src/tools/sound.js', () => ({ __esModule: true, default: jest.fn() }))
+import QuickTimer from 'pages/Timer/QuickTimer.vue'
+import { useAppStore } from 'stores/appStore'
+
+installQuasarPlugin()
+
+describe('QuickTimer', () => {
+  let wrapper
+  let store
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    store = useAppStore()
+    wrapper = shallowMount(QuickTimer, {
+      global: {
+        plugins: [pinia],
+        mocks: { $router: { go: jest.fn() } },
+        stubs: {
+          'q-page': true,
+          'q-btn': true,
+          'q-knob': true,
+          'q-popup-edit': true,
+          'q-input': true
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('counts down and resets when finished', async () => {
+    wrapper.vm.time = 1
+    wrapper.vm.startTimer()
+    expect(wrapper.vm.isActive).toBe(true)
+    jest.advanceTimersByTime(1000)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.timer_finished).toBe(true)
+    expect(wrapper.vm.progress).toBe(0)
+    expect(wrapper.vm.isActive).toBe(false)
+  })
+
+  it('stopTimer resets state', () => {
+    wrapper.vm.time = 5
+    wrapper.vm.startTimer()
+    jest.advanceTimersByTime(1000)
+    wrapper.vm.stopTimer()
+    expect(wrapper.vm.isActive).toBe(false)
+    expect(wrapper.vm.timer_finished).toBe(false)
+    expect(wrapper.vm.progress).toBe(0)
+  })
+})

--- a/test/jest/__tests__/useTimer.spec.js
+++ b/test/jest/__tests__/useTimer.spec.js
@@ -1,0 +1,49 @@
+import { describe, it, beforeEach, afterEach, expect, jest } from '@jest/globals'
+import { mount } from '@vue/test-utils'
+import useTimer from 'src/composables/useTimer'
+
+const TestComponent = {
+  template: '<div />',
+  setup () {
+    return useTimer()
+  }
+}
+
+describe('useTimer composable', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('increments progress and resets on stop', () => {
+    const wrapper = mount(TestComponent)
+    wrapper.vm.start()
+    jest.advanceTimersByTime(3000)
+    expect(wrapper.vm.progress).toBe(3)
+    expect(wrapper.vm.isActive).toBe(true)
+    wrapper.vm.stop()
+    expect(wrapper.vm.progress).toBe(0)
+    expect(wrapper.vm.isActive).toBe(false)
+  })
+
+  it('stop(false) keeps progress', () => {
+    const wrapper = mount(TestComponent)
+    wrapper.vm.start()
+    jest.advanceTimersByTime(1000)
+    wrapper.vm.stop(false)
+    expect(wrapper.vm.progress).toBe(1)
+    expect(wrapper.vm.isActive).toBe(false)
+  })
+
+  it('clears interval on unmount', () => {
+    const wrapper = mount(TestComponent)
+    wrapper.vm.start()
+    jest.advanceTimersByTime(1000)
+    wrapper.unmount()
+    expect(wrapper.vm.progress).toBe(0)
+    expect(wrapper.vm.isActive).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- register Quasar components in existing specs
- add tests for QuickTimer and ProgramTimer components
- test extracted useTimer composable

## Testing
- `npm run test:unit:ci`

------
https://chatgpt.com/codex/tasks/task_e_6873afe0c2b48322adb1e7baec1e5dda