### PR TITLE
Rename store getter for essential links

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -54,7 +54,7 @@ export default {
     return {
       toggleLeftDrawer: false,
       leftDrawerOpen: false,
-      essentialLinks: this.store.essentialLinks
+      essentialLinks: this.store.getEssentialLinks
     }
   },
   computed: {

--- a/src/stores/appStore.js
+++ b/src/stores/appStore.js
@@ -56,7 +56,7 @@ export const useAppStore = defineStore('app', {
     }
   },
   getters: {
-    essentialLinks: state => state.essentialLinks,
+    getEssentialLinks: state => state.essentialLinks,
     env: state => state.ENV,
     settings: state => state.SETTINGS,
     lastPreset: state => state.LAST_PRESET || defaultPreset,


### PR DESCRIPTION
## Summary
- rename `essentialLinks` getter to `getEssentialLinks`
- use `getEssentialLinks` in `MainLayout.vue`

## Testing
- `npm run lint`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6873b86e6fb08322bf35479a0db0138c