### PR TITLE
Move ENV to .env and enhance QuickTimer

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+APP_URL=http://localhost:3000
+APP_VERSION=v202308
+APP_NAME=Sportfreunde 2.0

--- a/src/pages/Timer/QuickTimer.vue
+++ b/src/pages/Timer/QuickTimer.vue
@@ -17,7 +17,7 @@
 
       <!-- CIRCLE -->
       <div class="col-7">
-        <q-knob show-value class="text-white q-ma-md" v-model="TIMER_VALUE" size="150px" :thickness="0.2" color="green-4"
+        <q-knob show-value class="text-white q-ma-md timer-knob" v-model="TIMER_VALUE" size="180px" :thickness="0.2" color="green-4"
           :center-color="timer_finished ? 'green-4' : 'grey-6'" track-color="transparent" readonly="">
           <div>
             <div>{{ time - progress }}
@@ -36,6 +36,20 @@
           <q-btn class="my-decent-text" color="positive" @click="addTime(1)" round>+1</q-btn>
           <q-btn class="my-decent-text" color="negative" @click="addTime(-1)" round>-1</q-btn>
           <q-btn class="my-decent-text" color="negative" @click="addTime(-5)" round>-5</q-btn>
+        </div>
+      </div>
+      <div class="col-2">
+        <div class="row justify-center q-gutter-sm" v-if="store.pinnedTimers.length">
+          <q-chip v-for="t in store.pinnedTimers" :key="'p'+t" class="pinned-chip" clickable @click="selectTime(t)">
+            {{ t }}s
+            <q-icon name="push_pin" size="xs" class="q-ml-xs" @click.stop="unpinTimer(t)" />
+          </q-chip>
+        </div>
+        <div class="row justify-center q-gutter-sm" v-if="store.recentTimers.length">
+          <q-chip v-for="t in store.recentTimers" :key="'r'+t" class="recent-chip" clickable @click="selectTime(t)">
+            {{ t }}s
+            <q-icon name="push_pin" size="xs" class="q-ml-xs" @click.stop="pinTimer(t)" />
+          </q-chip>
         </div>
       </div>
 
@@ -106,6 +120,7 @@ export default {
           this.stopInterval()
           this.timer_finished = true
           this.store.setSettingsQuickTimerStartValue(this.time)
+          this.store.addRecentTimer(this.time)
         }
       })
 
@@ -114,6 +129,16 @@ export default {
     stopTimer() {
       this.stopInterval()
       this.timer_finished = false
+    },
+    selectTime(t) {
+      this.time = t
+      this.timer_finished = false
+    },
+    pinTimer(t) {
+      this.store.pinTimer(t)
+    },
+    unpinTimer(t) {
+      this.store.unpinTimer(t)
     }
 
 
@@ -122,3 +147,18 @@ export default {
 }
 
 </script>
+
+<style scoped>
+.timer-knob {
+  box-shadow: 0 0 15px rgba(0, 255, 100, 0.6);
+  border-radius: 50%;
+}
+.pinned-chip {
+  background-color: #ffc107;
+  color: #000;
+}
+.recent-chip {
+  background-color: #555;
+  color: #fff;
+}
+</style>

--- a/src/stores/appStore.js
+++ b/src/stores/appStore.js
@@ -33,12 +33,23 @@ export const useAppStore = defineStore('app', {
       presets = null
     }
 
+    let recentTimers
+    try {
+      const rawRecent = localStorage.getItem('recent_timers')
+      if (rawRecent !== null) recentTimers = JSON.parse(rawRecent)
+    } catch (e) {
+      recentTimers = []
+    }
+
+    let pinnedTimers
+    try {
+      const rawPinned = localStorage.getItem('pinned_timers')
+      if (rawPinned !== null) pinnedTimers = JSON.parse(rawPinned)
+    } catch (e) {
+      pinnedTimers = []
+    }
+
     return {
-      ENV: {
-        APP_URL: 'http://localhost:3000',
-        APP_VERSION: 'v202308',
-        APP_NAME: 'Sportfreunde 2.0'
-      },
       SETTINGS: {
         audio_playback: true,
         quick_timer_start_value: 20 // in seconds
@@ -46,6 +57,8 @@ export const useAppStore = defineStore('app', {
       LAST_PRESET: lastPreset || undefined,
       PRESETS: presets || templatePresets,
       PROGRAM_STEPS: [],
+      RECENT_TIMERS: recentTimers || [],
+      PINNED_TIMERS: pinnedTimers || [],
       essentialLinks: [
         { titel: 'Home', caption: 'zurück', icon: 'home', route: 'Index' },
         { seperator: true },
@@ -57,11 +70,17 @@ export const useAppStore = defineStore('app', {
   },
   getters: {
     getEssentialLinks: state => state.essentialLinks,
-    env: state => state.ENV,
+    env: () => ({
+      APP_URL: process.env.APP_URL,
+      APP_VERSION: process.env.APP_VERSION,
+      APP_NAME: process.env.APP_NAME
+    }),
     settings: state => state.SETTINGS,
     lastPreset: state => state.LAST_PRESET || defaultPreset,
     presets: state => state.PRESETS,
-    programSteps: state => state.PROGRAM_STEPS
+    programSteps: state => state.PROGRAM_STEPS,
+    recentTimers: state => state.RECENT_TIMERS,
+    pinnedTimers: state => state.PINNED_TIMERS
   },
     actions: {
       setSettingsAudioPlayback(payload) {
@@ -84,6 +103,21 @@ export const useAppStore = defineStore('app', {
         console.log({ message: 'REMOVE_PRESET' })
         this.PRESETS = this.PRESETS.filter(preset => preset.label !== label)
         window.localStorage.setItem('presets', JSON.stringify(this.PRESETS))
+      },
+      addRecentTimer(duration) {
+        this.RECENT_TIMERS.unshift(duration)
+        this.RECENT_TIMERS = this.RECENT_TIMERS.slice(0, 3)
+        window.localStorage.setItem('recent_timers', JSON.stringify(this.RECENT_TIMERS))
+      },
+      pinTimer(duration) {
+        if (!this.PINNED_TIMERS.includes(duration)) {
+          this.PINNED_TIMERS.push(duration)
+          window.localStorage.setItem('pinned_timers', JSON.stringify(this.PINNED_TIMERS))
+        }
+      },
+      unpinTimer(duration) {
+        this.PINNED_TIMERS = this.PINNED_TIMERS.filter(t => t !== duration)
+        window.localStorage.setItem('pinned_timers', JSON.stringify(this.PINNED_TIMERS))
       },
       addProgramStep(step) {
         this.PROGRAM_STEPS.push(step)


### PR DESCRIPTION
## Summary
- shift ENV configuration to `.env`
- extend `appStore` to expose env vars, pinned timers, and recent timers
- improve `QuickTimer` styling with knob glow
- show pinned and recent timers with pin/unpin functionality

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68737925b60483228e05eb5434ce32d1