### PR TITLE
Add pinning store tests and big step check

### DIFF
--- a/test/jest/__tests__/QuickTimer.spec.js
+++ b/test/jest/__tests__/QuickTimer.spec.js
@@ -56,4 +56,11 @@ describe('QuickTimer', () => {
     expect(wrapper.vm.timer_finished).toBe(false)
     expect(wrapper.vm.progress).toBe(0)
   })
+
+  it('updates step size when timer exceeds 60 seconds', () => {
+    wrapper.vm.time = 55
+    expect(wrapper.vm.bigStep).toBe(5)
+    wrapper.vm.time = 65
+    expect(wrapper.vm.bigStep).toBe(10)
+  })
 })

--- a/test/jest/__tests__/appStore.spec.js
+++ b/test/jest/__tests__/appStore.spec.js
@@ -1,0 +1,29 @@
+import { beforeEach, describe, it, expect } from '@jest/globals'
+import { createPinia, setActivePinia } from 'pinia'
+import { useAppStore } from 'stores/appStore'
+
+describe('appStore pinning', () => {
+  let store
+  beforeEach(() => {
+    localStorage.clear()
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    store = useAppStore()
+  })
+
+  it('pinTimer keeps only three entries', () => {
+    store.pinTimer(10)
+    store.pinTimer(20)
+    store.pinTimer(30)
+    expect(store.pinnedTimers).toEqual([30, 20, 10])
+    store.pinTimer(40)
+    expect(store.pinnedTimers).toEqual([40, 30, 20])
+  })
+
+  it('unpinTimer removes an entry', () => {
+    store.pinTimer(10)
+    store.pinTimer(20)
+    store.unpinTimer(10)
+    expect(store.pinnedTimers).toEqual([20])
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for pinTimer and unpinTimer ensuring correct pin list behavior
- verify QuickTimer big step changes when time exceeds 60 seconds

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68742b458ac88322884cc9aac815d68b