### PR TITLE
Add pin toggle button for QuickTimer

### DIFF
--- a/src/pages/Timer/QuickTimer.vue
+++ b/src/pages/Timer/QuickTimer.vue
@@ -65,6 +65,17 @@
             <div class="my-small-text">Sekunden</div>
           </div>
         </q-knob>
+        <q-btn
+          flat
+          round
+          dense
+          size="sm"
+          icon="push_pin"
+          :color="isPinned ? 'amber-7' : 'grey-6'"
+          @click="togglePin"
+          class="absolute"
+          style="top: 10px; right: 10px"
+        />
       </div>
       <div class="col-1">
         <div class="row justify-center q-gutter-md" v-if="!isActive">
@@ -116,7 +127,7 @@
         {{ t }}s
       </q-btn>
       <q-btn
-        v-for="t in store.recentTimers"
+        v-for="t in filteredRecentTimers"
         :key="'r' + t"
         round
         size="sm"
@@ -161,6 +172,14 @@ export default {
     },
     bigStep() {
       return this.time >= 60 ? 10 : 5;
+    },
+    isPinned() {
+      return this.store.pinnedTimers.includes(this.time);
+    },
+    filteredRecentTimers() {
+      return this.store.recentTimers.filter(
+        (t) => !this.store.pinnedTimers.includes(t)
+      );
     },
   },
 
@@ -221,6 +240,13 @@ export default {
     },
     unpinTimer(t) {
       this.store.unpinTimer(t);
+    },
+    togglePin() {
+      if (this.isPinned) {
+        this.unpinTimer(this.time);
+      } else {
+        this.pinTimer(this.time);
+      }
     },
 
     // ENDE

--- a/test/jest/__tests__/QuickTimer.spec.js
+++ b/test/jest/__tests__/QuickTimer.spec.js
@@ -16,6 +16,7 @@ describe('QuickTimer', () => {
     jest.useFakeTimers()
     const pinia = createPinia()
     setActivePinia(pinia)
+    localStorage.clear()
     store = useAppStore()
     wrapper = shallowMount(QuickTimer, {
       global: {
@@ -62,5 +63,20 @@ describe('QuickTimer', () => {
     expect(wrapper.vm.bigStep).toBe(5)
     wrapper.vm.time = 65
     expect(wrapper.vm.bigStep).toBe(10)
+  })
+
+  it('togglePin pins and unpins the current timer', () => {
+    wrapper.vm.time = 5
+    wrapper.vm.togglePin()
+    expect(store.pinnedTimers).toContain(5)
+    wrapper.vm.togglePin()
+    expect(store.pinnedTimers).not.toContain(5)
+  })
+
+  it('filteredRecentTimers excludes pinned values', () => {
+    store.addRecentTimer(5)
+    store.addRecentTimer(10)
+    store.pinTimer(10)
+    expect(wrapper.vm.filteredRecentTimers).toEqual([5])
   })
 })


### PR DESCRIPTION
## Summary
- filter duplicate quick timers from the recent list
- let QuickTimer toggle pin state
- test pin/unpin functionality

## Testing
- `npm install`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6874a4d4f1848322b6e12cf0ad1d141a