### PR TITLE
Add DurationSlider component

### DIFF
--- a/src/components/DurationSlider.vue
+++ b/src/components/DurationSlider.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="row items-center q-gutter-sm">
+    <q-slider
+      v-model="proxyValue"
+      :step="step"
+      :min="min"
+      :max="max"
+      color="white"
+      label
+      label-text-color="dark"
+      thumb-size="40px"
+      class="col-grow"
+    />
+    <q-btn flat dense round size="sm" icon="edit" @click.stop="openEdit" />
+    <q-popup-edit ref="popup" v-model="proxyValue" auto-save>
+      <q-input
+        type="number"
+        v-model.number="proxyValue"
+        dense
+        autofocus
+        :min="min"
+        :max="max"
+        @keyup.enter="closeEdit"
+      />
+    </q-popup-edit>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, computed } from 'vue'
+
+const props = defineProps({
+  modelValue: {
+    type: Number,
+    required: true
+  },
+  min: {
+    type: Number,
+    default: 0
+  },
+  max: {
+    type: Number,
+    default: 3600
+  }
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const proxyValue = ref(props.modelValue)
+
+watch(() => props.modelValue, (val) => {
+  proxyValue.value = val
+})
+
+watch(proxyValue, (val) => {
+  emit('update:modelValue', val)
+})
+
+const step = computed(() => proxyValue.value <= 60 ? 5 : 10)
+
+const popup = ref(null)
+function openEdit () {
+  popup.value && popup.value.show()
+}
+function closeEdit () {
+  popup.value && popup.value.hide()
+}
+</script>

--- a/src/pages/Timer/ProgrammTimer.vue
+++ b/src/pages/Timer/ProgrammTimer.vue
@@ -64,8 +64,7 @@
                 <q-btn icon="clear" flat round class="absolute-top-right z-top" v-close-popup />
                 <q-card-section>Action anpassen</q-card-section>
                 <q-card-section>
-                  <q-slider v-model="localData.action.value" color="white" label label-text-color="dark" thumb-size="50px"
-                    :step="1" :min="5" :max="120" />
+                  <DurationSlider v-model="localData.action.value" :min="5" :max="3600" />
                 </q-card-section>
               </q-card>
             </q-popup-proxy>
@@ -81,8 +80,7 @@
                 <q-btn icon="clear" flat round class="absolute-top-right z-top" v-close-popup />
                 <q-card-section>Pause anpassen</q-card-section>
                 <q-card-section>
-                  <q-slider v-model="localData.break.value" color="white" label label-text-color="dark" thumb-size="50px"
-                    :step="1" :min="0" :max="60" />
+                  <DurationSlider v-model="localData.break.value" :min="0" :max="3600" />
                 </q-card-section>
               </q-card>
             </q-popup-proxy>
@@ -132,8 +130,7 @@
                 <q-btn icon="clear" flat round class="absolute-top-right z-top" v-close-popup />
                 <q-card-section>Rundenpause anpassen</q-card-section>
                 <q-card-section>
-                  <q-slider v-model="localData.round_break.value" label label-text-color="dark" color="white"
-                    thumb-size="50px" :step="1" :min="0" :max="60" />
+                  <DurationSlider v-model="localData.round_break.value" :min="0" :max="3600" />
                 </q-card-section>
               </q-card>
             </q-popup-proxy>
@@ -151,7 +148,7 @@
               <q-select dense emit-value map-options :options="STEP_OPTIONS" v-model="step.type" />
             </q-item-section>
             <q-item-section>
-              <q-slider v-model="step.duration" color="white" label label-text-color="dark" thumb-size="40px" :min="1" :max="300" />
+              <DurationSlider v-model="step.duration" :min="1" :max="3600" />
             </q-item-section>
             <q-item-section side>
               <q-input v-model.number="step.repetitions" type="number" dense style="width:50px" />
@@ -214,6 +211,7 @@
 
 <script>
 import MY_ITEM_BTN from 'components/MyItemBtn.vue'
+import DurationSlider from 'components/DurationSlider.vue'
 import getRandomCitation from 'src/tools/citate.js'
 import { useAppStore } from 'stores/appStore'
 import playSound from 'src/tools/sound.js'
@@ -222,7 +220,8 @@ import useTimer from 'src/composables/useTimer'
 export default {
   name: 'ProgrammTimer',
   components: {
-    MY_ITEM_BTN
+    MY_ITEM_BTN,
+    DurationSlider
   },
   setup () {
     const store = useAppStore()

--- a/test/jest/__tests__/ProgramTimer.spec.js
+++ b/test/jest/__tests__/ProgramTimer.spec.js
@@ -33,6 +33,7 @@ describe('ProgramTimer', () => {
           'q-popup-proxy': true,
           'q-card': true,
           'q-card-section': true,
+          'duration-slider': true,
           'q-slider': true,
           'q-select': true,
           'q-input': true,


### PR DESCRIPTION
## Summary
- introduce `DurationSlider.vue` for editing time values with slider or popup
- replace old `q-slider` duration controls in `ProgrammTimer.vue` with the new component
- update unit test stubs

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6874ba2ed66c832285462324903d4358