### PR TITLE
Fix duration calc when no steps

### DIFF
--- a/src/pages/Timer/ProgrammTimer.vue
+++ b/src/pages/Timer/ProgrammTimer.vue
@@ -243,7 +243,7 @@ export default {
   },
   mounted() {
     if (this.programSteps.length === 0) {
-      this.addStep()
+      this.generateStepsFromSettings()
     }
   },
 
@@ -312,7 +312,8 @@ export default {
 
     DURATION_CALC() {
       if (this.TIME_DATA) return this.calcDuration(this.TIME_DATA)
-      else return this.calcDuration(this.programSteps)
+      if (this.programSteps.length) return this.calcDuration(this.programSteps)
+      return this.calcDuration(this.localData)
 
     },
 

--- a/test/jest/__tests__/ProgramTimer.spec.js
+++ b/test/jest/__tests__/ProgramTimer.spec.js
@@ -80,4 +80,39 @@ describe('ProgramTimer', () => {
       { type: 'action', duration: 2, repetitions: 1 }
     ])
   })
+
+  it('uses last preset duration when no program steps exist on mount', () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    localStorage.clear()
+    const localStore = useAppStore()
+    const altWrapper = shallowMount(ProgramTimer, {
+      global: {
+        plugins: [pinia],
+        mocks: { $router: { go: jest.fn() } },
+        stubs: {
+          'q-page': true,
+          'q-btn': true,
+          'q-chip': true,
+          'q-list': true,
+          'q-item': true,
+          'q-item-section': true,
+          'q-btn-dropdown': true,
+          'q-popup-proxy': true,
+          'q-card': true,
+          'q-card-section': true,
+          'duration-slider': true,
+          'q-slider': true,
+          'q-select': true,
+          'q-input': true,
+          'q-tooltip': true,
+          'q-separator': true,
+          'q-icon': true,
+          'q-knob': true
+        }
+      }
+    })
+    const expected = altWrapper.vm.calcDuration(localStore.lastPreset)
+    expect(altWrapper.vm.DURATION_CALC).toBe(expected)
+  })
 })


### PR DESCRIPTION
## Summary
- auto-generate program steps when mounting with none
- calc duration based on TIME_DATA, program steps, or settings
- test DURATION_CALC with empty store program steps

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6874c11670f883229bbe1e72ded46d76