### PR TITLE
Add formatted duration slider label

### DIFF
--- a/src/components/DurationSlider.vue
+++ b/src/components/DurationSlider.vue
@@ -5,6 +5,7 @@
       :step="step"
       :min="min"
       :max="max"
+      :label-value="labelValue"
       color="white"
       label
       label-text-color="dark"
@@ -27,42 +28,55 @@
 </template>
 
 <script setup>
-import { ref, watch, computed } from 'vue'
+import { ref, watch, computed } from "vue";
 
 const props = defineProps({
   modelValue: {
     type: Number,
-    required: true
+    required: true,
   },
   min: {
     type: Number,
-    default: 0
+    default: 0,
   },
   max: {
     type: Number,
-    default: 3600
+    default: 3600,
+  },
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+const proxyValue = ref(props.modelValue);
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    proxyValue.value = val;
   }
-})
-
-const emit = defineEmits(['update:modelValue'])
-
-const proxyValue = ref(props.modelValue)
-
-watch(() => props.modelValue, (val) => {
-  proxyValue.value = val
-})
+);
 
 watch(proxyValue, (val) => {
-  emit('update:modelValue', val)
-})
+  emit("update:modelValue", val);
+});
 
-const step = computed(() => proxyValue.value <= 60 ? 5 : 10)
+const step = computed(() => (proxyValue.value < 60 ? 5 : 10));
 
-const popup = ref(null)
-function openEdit () {
-  popup.value && popup.value.show()
+const labelValue = computed(() => {
+  const val = proxyValue.value;
+  if (val < 60) {
+    return `${val}s`;
+  }
+  const minutes = Math.floor(val / 60);
+  const seconds = val % 60;
+  return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`;
+});
+
+const popup = ref(null);
+function openEdit() {
+  popup.value && popup.value.show();
 }
-function closeEdit () {
-  popup.value && popup.value.hide()
+function closeEdit() {
+  popup.value && popup.value.hide();
 }
 </script>

--- a/test/jest/__tests__/DurationSlider.spec.js
+++ b/test/jest/__tests__/DurationSlider.spec.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "@jest/globals";
+import { installQuasarPlugin } from "@quasar/quasar-app-extension-testing-unit-jest";
+import { shallowMount } from "@vue/test-utils";
+import DurationSlider from "components/DurationSlider.vue";
+
+installQuasarPlugin();
+
+describe("DurationSlider", () => {
+  function mountSlider(value) {
+    return shallowMount(DurationSlider, {
+      props: { modelValue: value },
+      global: {
+        stubs: {
+          "q-slider": true,
+          "q-btn": true,
+          "q-popup-edit": true,
+          "q-input": true,
+        },
+      },
+    });
+  }
+
+  it("formats label for values below 60s", () => {
+    const wrapper = mountSlider(30);
+    expect(wrapper.vm.labelValue).toBe("30s");
+    expect(wrapper.vm.step).toBe(5);
+  });
+
+  it("formats label for values of one minute or more", () => {
+    const wrapper = mountSlider(75);
+    expect(wrapper.vm.labelValue).toBe("1m 15s");
+    expect(wrapper.vm.step).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
- display formatted seconds for `DurationSlider`
- compute slider step by current seconds
- test label formatting for sub-minute and minute+ values

## Testing
- `npm run lint`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6874c1f8dca48322a5ab5620d525db2c