### PR TITLE
Remove unused addStep feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A Quasar/Vue 3 timer application for organizing workouts. The app offers Quick Timer and Program Timer modes and lets you invite friends to share sessions.
 
+### Program Timer
+Workout steps are created automatically from your preset settings. Manual step addition is no longer available.
+
 ## Project setup
 Install dependencies using npm or yarn:
 

--- a/src/pages/Timer/ProgrammTimer.vue
+++ b/src/pages/Timer/ProgrammTimer.vue
@@ -144,10 +144,6 @@
 
 
           <q-separator class="q-my-md" />
-          <q-item class="q-ma-sm" clickable @click="addStep">
-            <q-item-section avatar><q-icon name="add" /></q-item-section>
-            <q-item-section>Schritt hinzufügen</q-item-section>
-          </q-item>
           <q-item v-for="(step, idx) in programSteps" :key="'step'+idx" class="q-ma-sm bg-grey-9" draggable
             @dragstart="onDragStart(idx)" @dragover.prevent @drop="onDrop(idx)">
             <q-item-section avatar>
@@ -484,10 +480,6 @@ export default {
       })
 
 
-    },
-
-    addStep() {
-      this.store.addProgramStep({ type: 'action', duration: 30, repetitions: 1 })
     },
 
     removeStep(index) {

--- a/src/stores/appStore.js
+++ b/src/stores/appStore.js
@@ -144,9 +144,6 @@ export const useAppStore = defineStore("app", {
         JSON.stringify(this.PINNED_TIMERS)
       );
     },
-    addProgramStep(step) {
-      this.PROGRAM_STEPS.push(step);
-    },
     removeProgramStep(index) {
       this.PROGRAM_STEPS.splice(index, 1);
     },

--- a/test/jest/__tests__/ProgramTimer.spec.js
+++ b/test/jest/__tests__/ProgramTimer.spec.js
@@ -17,7 +17,7 @@ describe('ProgramTimer', () => {
     const pinia = createPinia()
     setActivePinia(pinia)
     store = useAppStore()
-    store.addProgramStep({ type: 'action', duration: 1, repetitions: 1 })
+    store.PROGRAM_STEPS = [{ type: 'action', duration: 1, repetitions: 1 }]
     wrapper = shallowMount(ProgramTimer, {
       global: {
         plugins: [pinia],
@@ -149,21 +149,4 @@ describe('ProgramTimer', () => {
     expect(wrapper.vm.isActive).toBe(false)
   })
 
-  it('retains added steps when settings change', async () => {
-    const initial = store.programSteps.length
-    wrapper.vm.addStep()
-    expect(store.programSteps.length).toBe(initial + 1)
-    wrapper.vm.localData.action.value = 10
-    await wrapper.vm.$nextTick()
-    expect(store.programSteps.length).toBe(initial + 1)
-  })
-
-  it('keeps remaining steps after removal and settings update', async () => {
-    wrapper.vm.addStep()
-    wrapper.vm.removeStep(0)
-    const stepsSnapshot = JSON.parse(JSON.stringify(store.programSteps))
-    wrapper.vm.localData.break.value = 5
-    await wrapper.vm.$nextTick()
-    expect(store.programSteps).toEqual(stepsSnapshot)
-  })
 })


### PR DESCRIPTION
## Summary
- drop addStep button and logic from `ProgrammTimer.vue`
- delete unused `addProgramStep` store action
- update ProgramTimer unit tests to match
- document auto-generated steps in README

## Testing
- `npm run test:unit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6874d39601988322a86355531ca619bf