### PR TITLE
Fix ProgramTimer auto generation

### DIFF
--- a/src/pages/Timer/ProgrammTimer.vue
+++ b/src/pages/Timer/ProgrammTimer.vue
@@ -444,9 +444,7 @@ export default {
     };
   },
   mounted() {
-    if (this.programSteps.length === 0) {
-      this.generateStepsFromSettings();
-    }
+    this.store.PROGRAM_STEPS = [];
   },
 
   computed: {
@@ -532,14 +530,6 @@ export default {
   },
 
   watch: {
-    localData: {
-      deep: true,
-      handler() {
-        if (this.programSteps.length === 0) {
-          this.generateStepsFromSettings();
-        }
-      },
-    },
     "localData.exercises.value"(val) {
       if (val > this.localData.exerciseNames.length) {
         for (let i = this.localData.exerciseNames.length; i < val; i++) {
@@ -621,7 +611,6 @@ export default {
         this.localData.rounds.value = preset.data.rounds.value;
         this.localData.round_break.value = preset.data.round_break.value;
         this.localData.label = preset.label;
-        this.generateStepsFromSettings();
       }
     },
 

--- a/test/jest/__tests__/ProgramTimer.spec.js
+++ b/test/jest/__tests__/ProgramTimer.spec.js
@@ -1,152 +1,147 @@
-import { beforeEach, afterEach, describe, it, expect, jest } from '@jest/globals'
-import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest'
-import { shallowMount } from '@vue/test-utils'
-import { createPinia, setActivePinia } from 'pinia'
-jest.mock('src/tools/sound.js', () => ({ __esModule: true, default: jest.fn() }))
-import ProgramTimer from 'pages/Timer/ProgrammTimer.vue'
-import { useAppStore } from 'stores/appStore'
+import {
+  beforeEach,
+  afterEach,
+  describe,
+  it,
+  expect,
+  jest,
+} from "@jest/globals";
+import { installQuasarPlugin } from "@quasar/quasar-app-extension-testing-unit-jest";
+import { shallowMount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+jest.mock("src/tools/sound.js", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+import ProgramTimer from "pages/Timer/ProgrammTimer.vue";
+import { useAppStore } from "stores/appStore";
 
-installQuasarPlugin()
+installQuasarPlugin();
 
-describe('ProgramTimer', () => {
-  let wrapper
-  let store
+describe("ProgramTimer", () => {
+  let wrapper;
+  let store;
 
   beforeEach(() => {
-    jest.useFakeTimers()
-    const pinia = createPinia()
-    setActivePinia(pinia)
-    store = useAppStore()
-    store.PROGRAM_STEPS = [{ type: 'action', duration: 1, repetitions: 1 }]
+    jest.useFakeTimers();
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    store = useAppStore();
+    store.PROGRAM_STEPS = [{ type: "action", duration: 1, repetitions: 1 }];
     wrapper = shallowMount(ProgramTimer, {
       global: {
         plugins: [pinia],
         mocks: { $router: { go: jest.fn() } },
         stubs: {
-          'q-page': true,
-          'q-btn': true,
-          'q-chip': true,
-          'q-list': true,
-          'q-item': true,
-          'q-item-section': true,
-          'q-btn-dropdown': true,
-          'q-popup-proxy': true,
-          'q-card': true,
-          'q-card-section': true,
-          'duration-slider': true,
-          'q-slider': true,
-          'q-select': true,
-          'q-input': true,
-          'q-tooltip': true,
-          'q-separator': true,
-          'q-icon': true,
-          'q-knob': true
-        }
-      }
-    })
-  })
+          "q-page": true,
+          "q-btn": true,
+          "q-chip": true,
+          "q-list": true,
+          "q-item": true,
+          "q-item-section": true,
+          "q-btn-dropdown": true,
+          "q-popup-proxy": true,
+          "q-card": true,
+          "q-card-section": true,
+          "duration-slider": true,
+          "q-slider": true,
+          "q-select": true,
+          "q-input": true,
+          "q-tooltip": true,
+          "q-separator": true,
+          "q-icon": true,
+          "q-knob": true,
+        },
+      },
+    });
+  });
 
   afterEach(() => {
-    jest.useRealTimers()
-  })
+    jest.useRealTimers();
+  });
 
-  it('runs program and resets progress when finished', () => {
-    wrapper.vm.TIME_DATA = wrapper.vm._prepareTimer()
-    wrapper.vm.nextTimer()
-    jest.advanceTimersByTime(1000)
-    expect(wrapper.vm.timer_finished).toBe(true)
-    expect(wrapper.vm.progress).toBe(0)
-  })
+  it("runs program and resets progress when finished", () => {
+    wrapper.vm.TIME_DATA = wrapper.vm._prepareTimer();
+    wrapper.vm.nextTimer();
+    jest.advanceTimersByTime(1000);
+    expect(wrapper.vm.timer_finished).toBe(true);
+    expect(wrapper.vm.progress).toBe(0);
+  });
 
-  it('stopTimer halts timer and resets progress', () => {
-    wrapper.vm.startTimer()
-    jest.advanceTimersByTime(1500)
-    jest.advanceTimersByTime(500)
-    wrapper.vm.stopTimer()
-    expect(wrapper.vm.timer_halted).toBe(true)
-    expect(wrapper.vm.progress).toBe(0)
-  })
+  it("stopTimer halts timer and resets progress", () => {
+    wrapper.vm.startTimer();
+    jest.advanceTimersByTime(1500);
+    jest.advanceTimersByTime(500);
+    wrapper.vm.stopTimer();
+    expect(wrapper.vm.timer_halted).toBe(true);
+    expect(wrapper.vm.progress).toBe(0);
+  });
 
-  it('generates program steps from settings', () => {
-    wrapper.vm.localData.action.value = 2
-    wrapper.vm.localData.break.value = 1
-    wrapper.vm.localData.exercises.value = 2
-    wrapper.vm.localData.rounds.value = 1
-    wrapper.vm.localData.round_break.value = 0
-    wrapper.vm.localData.exerciseNames = ['a', 'b']
-    wrapper.vm.generateStepsFromSettings()
+  it("generates program steps from settings", () => {
+    wrapper.vm.localData.action.value = 2;
+    wrapper.vm.localData.break.value = 1;
+    wrapper.vm.localData.exercises.value = 2;
+    wrapper.vm.localData.rounds.value = 1;
+    wrapper.vm.localData.round_break.value = 0;
+    wrapper.vm.localData.exerciseNames = ["a", "b"];
+    wrapper.vm.generateStepsFromSettings();
     expect(store.programSteps).toEqual([
-      { type: 'action', duration: 2, repetitions: 1, name: 'a' },
-      { type: 'break', duration: 1, repetitions: 1 },
-      { type: 'action', duration: 2, repetitions: 1, name: 'b' }
-    ])
-  })
+      { type: "action", duration: 2, repetitions: 1, name: "a" },
+      { type: "break", duration: 1, repetitions: 1 },
+      { type: "action", duration: 2, repetitions: 1, name: "b" },
+    ]);
+  });
 
-  it('prepares timer data including names', () => {
+  it("prepares timer data including names", () => {
     store.PROGRAM_STEPS = [
-      { type: 'action', duration: 1, repetitions: 1, name: 'x' }
-    ]
-    const times = wrapper.vm._prepareTimer()
-    expect(times[0].name).toBe('x')
-  })
+      { type: "action", duration: 1, repetitions: 1, name: "x" },
+    ];
+    const times = wrapper.vm._prepareTimer();
+    expect(times[0].name).toBe("x");
+  });
 
-  it('uses last preset duration when no program steps exist on mount', () => {
-    const pinia = createPinia()
-    setActivePinia(pinia)
-    localStorage.clear()
-    const localStore = useAppStore()
+  it("uses last preset duration when no program steps exist on mount", () => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    localStorage.clear();
+    const localStore = useAppStore();
     const altWrapper = shallowMount(ProgramTimer, {
       global: {
         plugins: [pinia],
         mocks: { $router: { go: jest.fn() } },
         stubs: {
-          'q-page': true,
-          'q-btn': true,
-          'q-chip': true,
-          'q-list': true,
-          'q-item': true,
-          'q-item-section': true,
-          'q-btn-dropdown': true,
-          'q-popup-proxy': true,
-          'q-card': true,
-          'q-card-section': true,
-          'duration-slider': true,
-          'q-slider': true,
-          'q-select': true,
-          'q-input': true,
-          'q-tooltip': true,
-          'q-separator': true,
-          'q-icon': true,
-          'q-knob': true
-        }
-      }
-    })
-    const expected = altWrapper.vm.calcDuration(localStore.lastPreset)
-    expect(altWrapper.vm.DURATION_CALC).toBe(expected)
-  })
+          "q-page": true,
+          "q-btn": true,
+          "q-chip": true,
+          "q-list": true,
+          "q-item": true,
+          "q-item-section": true,
+          "q-btn-dropdown": true,
+          "q-popup-proxy": true,
+          "q-card": true,
+          "q-card-section": true,
+          "duration-slider": true,
+          "q-slider": true,
+          "q-select": true,
+          "q-input": true,
+          "q-tooltip": true,
+          "q-separator": true,
+          "q-icon": true,
+          "q-knob": true,
+        },
+      },
+    });
+    const expected = altWrapper.vm.calcDuration(localStore.lastPreset);
+    expect(altWrapper.vm.DURATION_CALC).toBe(expected);
+  });
 
-  it('updates program when preset is selected', async () => {
-    const preset = store.presets.find(p => p.data)
-    wrapper.vm.selectPreset(preset)
-    await wrapper.vm.$nextTick()
+  it("updates program when preset is selected", async () => {
+    const preset = store.presets.find((p) => p.data);
+    wrapper.vm.selectPreset(preset);
+    await wrapper.vm.$nextTick();
 
-    const expectedSteps = []
-    const { action, break: brk, exercises, rounds, round_break } = preset.data
-    for (let r = 0; r < rounds.value; r++) {
-      for (let e = 0; e < exercises.value; e++) {
-        expectedSteps.push({ type: 'action', duration: action.value, repetitions: 1, name: undefined })
-        if (e < exercises.value - 1) {
-          expectedSteps.push({ type: 'break', duration: brk.value, repetitions: 1 })
-        }
-      }
-      if (r < rounds.value - 1) {
-        expectedSteps.push({ type: 'round_break', duration: round_break.value, repetitions: 1 })
-      }
-    }
-
-    expect(store.programSteps).toEqual(expectedSteps)
-    expect(wrapper.vm.DURATION_CALC).toBe(wrapper.vm.calcDuration(preset.data))
-    expect(wrapper.vm.isActive).toBe(false)
-  })
-
-})
+    expect(store.programSteps).toEqual([]);
+    expect(wrapper.vm.DURATION_CALC).toBe(wrapper.vm.calcDuration(preset.data));
+    expect(wrapper.vm.isActive).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- stop automatically creating program steps when the page is opened
- preserve empty step list after selecting a preset
- adjust unit tests for new behaviour

## Testing
- `npm run lint`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6874d02f90a083228503bf4e65a6d16a