### PR TITLE
Watch program timers

### DIFF
--- a/src/pages/Timer/ProgrammTimer.vue
+++ b/src/pages/Timer/ProgrammTimer.vue
@@ -533,6 +533,10 @@ export default {
   },
 
   watch: {
+    "localData.action.value": "generateStepsFromSettings",
+    "localData.break.value": "generateStepsFromSettings",
+    "localData.rounds.value": "generateStepsFromSettings",
+    "localData.round_break.value": "generateStepsFromSettings",
     "localData.exercises.value"(val) {
       if (val > this.localData.exerciseNames.length) {
         for (let i = this.localData.exerciseNames.length; i < val; i++) {
@@ -541,6 +545,7 @@ export default {
       } else if (val < this.localData.exerciseNames.length) {
         this.localData.exerciseNames.splice(val);
       }
+      this.generateStepsFromSettings();
     },
   },
 

--- a/test/jest/__tests__/ProgramTimer.spec.js
+++ b/test/jest/__tests__/ProgramTimer.spec.js
@@ -139,9 +139,17 @@ describe("ProgramTimer", () => {
     const preset = store.presets.find((p) => p.data);
     wrapper.vm.selectPreset(preset);
     await wrapper.vm.$nextTick();
-
-    expect(store.programSteps).toEqual([]);
     expect(wrapper.vm.DURATION_CALC).toBe(wrapper.vm.calcDuration(preset.data));
     expect(wrapper.vm.isActive).toBe(false);
+  });
+
+  it("recalculates duration when settings change", async () => {
+    const start = wrapper.vm.DURATION_CALC;
+    wrapper.vm.localData.action.value += 1;
+    wrapper.vm.generateStepsFromSettings();
+    await wrapper.vm.$nextTick();
+    const expected = wrapper.vm.calcDuration(wrapper.vm.programSteps);
+    expect(wrapper.vm.DURATION_CALC).toBe(expected);
+    expect(wrapper.vm.DURATION_CALC).not.toBe(start);
   });
 });


### PR DESCRIPTION
## Summary
- refresh program steps whenever settings change
- test that program updates recalc duration

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68754ad7a0f08322aabad51827fd1c84