### PR TITLE
Add step prop to DurationSlider

### DIFF
--- a/src/components/DurationSlider.vue
+++ b/src/components/DurationSlider.vue
@@ -35,6 +35,10 @@ const props = defineProps({
     type: Number,
     required: true,
   },
+  step: {
+    type: Number,
+    default: undefined,
+  },
   min: {
     type: Number,
     default: 0,
@@ -60,7 +64,7 @@ watch(proxyValue, (val) => {
   emit("update:modelValue", val);
 });
 
-const step = computed(() => (proxyValue.value < 60 ? 5 : 10));
+const step = computed(() => props.step ?? (proxyValue.value < 60 ? 5 : 10));
 
 const labelValue = computed(() => {
   const val = proxyValue.value;

--- a/src/pages/Timer/ProgrammTimer.vue
+++ b/src/pages/Timer/ProgrammTimer.vue
@@ -134,6 +134,7 @@
                     v-model="localData.action.value"
                     :min="5"
                     :max="3600"
+                    :step="5"
                   />
                 </q-card-section>
               </q-card>
@@ -159,6 +160,7 @@
                     v-model="localData.break.value"
                     :min="0"
                     :max="3600"
+                    :step="5"
                   />
                 </q-card-section>
               </q-card>
@@ -256,6 +258,7 @@
                     v-model="localData.round_break.value"
                     :min="0"
                     :max="3600"
+                    :step="5"
                   />
                 </q-card-section>
               </q-card>
@@ -299,6 +302,7 @@
                       v-model="step.duration"
                       :min="1"
                       :max="3600"
+                      :step="5"
                     />
                   </q-card-section>
                 </q-card>

--- a/test/jest/__tests__/DurationSlider.spec.js
+++ b/test/jest/__tests__/DurationSlider.spec.js
@@ -6,9 +6,9 @@ import DurationSlider from "components/DurationSlider.vue";
 installQuasarPlugin();
 
 describe("DurationSlider", () => {
-  function mountSlider(value) {
+  function mountSlider(value, props = {}) {
     return shallowMount(DurationSlider, {
-      props: { modelValue: value },
+      props: { modelValue: value, ...props },
       global: {
         stubs: {
           "q-slider": true,
@@ -30,5 +30,10 @@ describe("DurationSlider", () => {
     const wrapper = mountSlider(75);
     expect(wrapper.vm.labelValue).toBe("1m 15s");
     expect(wrapper.vm.step).toBe(10);
+  });
+
+  it("uses provided step prop", () => {
+    const wrapper = mountSlider(120, { step: 1 });
+    expect(wrapper.vm.step).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- allow custom step on DurationSlider while preserving default behaviour
- use finer step increments in ProgrammTimer
- test DurationSlider step prop

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_687551e7765c83229c55662e48a89330