### PR TITLE
Add separator between timer option groups

### DIFF
--- a/src/pages/Timer/ProgrammTimer.vue
+++ b/src/pages/Timer/ProgrammTimer.vue
@@ -206,14 +206,16 @@
                   </div>
                 </q-card-section>
               </q-card>
-            </q-dialog>
-          </div>
+          </q-dialog>
+        </div>
 
-          <!-- Repetitions -->
-          <div class="col-12">
-            <q-btn
-              no-caps
-              class="my-main-btn"
+        <q-separator class="q-my-md" />
+
+        <!-- Repetitions -->
+        <div class="col-12">
+          <q-btn
+            no-caps
+            class="my-main-btn"
               color="secondary"
               @click="showRoundsDialog = true"
             >


### PR DESCRIPTION
## Summary
- insert `<q-separator>` after exercise options in `ProgrammTimer.vue`
- keep spacing consistent for clearer grouping

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6875548f4f4483228d20d604751d5554