### PR TITLE
Fix markdown imports for Vite

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -1,47 +1,39 @@
 <template>
-  <q-page data-cy="page_about" class="page-size no-pointer-events non-selectable">
-
+  <q-page
+    data-cy="page_about"
+    class="page-size no-pointer-events non-selectable"
+  >
     <div class="column items-center q-px-xl">
       <div class="col">
-        <p v-html="missionTxt" class=" standard_text"></p>
+        <p v-html="missionTxt" class="standard_text"></p>
       </div>
-      <div class="col">
-
-      </div>
+      <div class="col"></div>
     </div>
-
-
   </q-page>
 </template>
 
 <script>
-import showdown from "showdown"
-import MD_TEXT from 'raw-loader!../../ABOUT.md'
-import { useAppStore } from 'stores/appStore'
+import showdown from "showdown";
+import MD_TEXT from "../../ABOUT.md?raw";
+import { useAppStore } from "stores/appStore";
 
 export default {
-  name: 'AboutPage',
-  components: {
-
-  },
-  setup () {
-    const store = useAppStore()
-    return { store }
+  name: "AboutPage",
+  components: {},
+  setup() {
+    const store = useAppStore();
+    return { store };
   },
   data() {
-    return {
-    }
+    return {};
   },
-  mounted() {
-
-  },
+  mounted() {},
   computed: {
     missionTxt() {
       var converter = new showdown.Converter(),
         html = converter.makeHtml(MD_TEXT);
-      return html
+      return html;
     },
   },
-}
-
+};
 </script>

--- a/src/pages/ChangeLogPage.vue
+++ b/src/pages/ChangeLogPage.vue
@@ -1,42 +1,34 @@
 <template>
-  <q-page data-cy="page_about" class="page-size no-pointer-events non-selectable">
-
+  <q-page
+    data-cy="page_about"
+    class="page-size no-pointer-events non-selectable"
+  >
     <div class="column items-center q-px-xl">
       <div class="col">
-        <p v-html="missionTxt" class=" standard_text"></p>
+        <p v-html="missionTxt" class="standard_text"></p>
       </div>
-      <div class="col">
-
-      </div>
+      <div class="col"></div>
     </div>
-
-
   </q-page>
 </template>
 
 <script>
-import showdown from "showdown"
-import MD_TEXT from 'raw-loader!../../CHANGELOG.md'
+import showdown from "showdown";
+import MD_TEXT from "../../CHANGELOG.md?raw";
 
 export default {
-  name: 'ChangeLogPage',
-  components: {
-
-  },
+  name: "ChangeLogPage",
+  components: {},
   data() {
-    return {
-    }
+    return {};
   },
-  mounted() {
-
-  },
+  mounted() {},
   computed: {
     missionTxt() {
       var converter = new showdown.Converter(),
         html = converter.makeHtml(MD_TEXT);
-      return html
+      return html;
     },
   },
-}
-
+};
 </script>

--- a/src/pages/ImpressumPage.vue
+++ b/src/pages/ImpressumPage.vue
@@ -1,47 +1,39 @@
 <template>
-  <q-page data-cy="page_about" class="page-size no-pointer-events non-selectable">
-
+  <q-page
+    data-cy="page_about"
+    class="page-size no-pointer-events non-selectable"
+  >
     <div class="column items-center q-px-xl">
       <div class="col">
-        <p v-html="missionTxt" class=" standard_text"></p>
+        <p v-html="missionTxt" class="standard_text"></p>
       </div>
-      <div class="col">
-
-      </div>
+      <div class="col"></div>
     </div>
-
-
   </q-page>
 </template>
 
 <script>
-import showdown from "showdown"
-import MD_TEXT from 'raw-loader!../../IMPRESSUM.md'
-import { useAppStore } from 'stores/appStore'
+import showdown from "showdown";
+import MD_TEXT from "../../IMPRESSUM.md?raw";
+import { useAppStore } from "stores/appStore";
 
 export default {
-  name: 'ImpressumPage',
-  components: {
-
-  },
-  setup () {
-    const store = useAppStore()
-    return { store }
+  name: "ImpressumPage",
+  components: {},
+  setup() {
+    const store = useAppStore();
+    return { store };
   },
   data() {
-    return {
-    }
+    return {};
   },
-  mounted() {
-
-  },
+  mounted() {},
   computed: {
     missionTxt() {
       var converter = new showdown.Converter(),
         html = converter.makeHtml(MD_TEXT);
-      return html
+      return html;
     },
   },
-}
-
+};
 </script>


### PR DESCRIPTION
## Summary
- load markdown files with Vite `?raw` query instead of `raw-loader`

## Testing
- `npx prettier --write src/pages/AboutPage.vue src/pages/ImpressumPage.vue src/pages/ChangeLogPage.vue`
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68757edaedc883229ca2a6bc262def1b