### PR TITLE
Add timer store and refactor QuickTimer

### DIFF
--- a/src/pages/Timer/QuickTimer.vue
+++ b/src/pages/Timer/QuickTimer.vue
@@ -1,16 +1,30 @@
 <template>
   <q-page data-cy="page_about" class="full-height">
-
     <!-- TOP BAR -->
     <div>
-      <q-btn icon="close" size="lg" flat round class="absolute-top-right" @click="goBack()" />
-      <q-btn :icon="!store.settings.audio_playback ? 'volume_off' : 'volume_up'" size="lg" flat round
-        class="absolute-top-left" @click="store.setSettingsAudioPlayback(!store.settings.audio_playback)" />
+      <q-btn
+        icon="close"
+        size="lg"
+        flat
+        round
+        class="absolute-top-right"
+        @click="goBack()"
+      />
+      <q-btn
+        :icon="!store.settings.audio_playback ? 'volume_off' : 'volume_up'"
+        size="lg"
+        flat
+        round
+        class="absolute-top-left"
+        @click="store.setSettingsAudioPlayback(!store.settings.audio_playback)"
+      />
     </div>
 
     <!-- CONTENT -->
-    <div class="column justify-center items-center" style="height: 100vh; width: 100vw">
-
+    <div
+      class="column justify-center items-center"
+      style="height: 100vh; width: 100vw"
+    >
       <!-- TITLE -->
       <div class="col-1 full-width text-center">QuickTimer</div>
 
@@ -18,28 +32,64 @@
       <!-- BTN -->
       <div class="col-2">
         <!-- START -->
-        <q-btn v-if="!isActive" class="my-main-btn" @click="startTimer()">Start</q-btn>
+        <q-btn v-if="!isActive" class="my-main-btn" @click="startTimer()"
+          >Start</q-btn
+        >
         <!-- STOP -->
-        <q-btn v-if="isActive" class="my-main-btn" @click="stopTimer()">Stop</q-btn>
+        <q-btn v-if="isActive" class="my-main-btn" @click="stopTimer()"
+          >Stop</q-btn
+        >
       </div>
 
       <!-- CIRCLE -->
-      <div class="col-6 row justify-center items-center" style="position: relative;">
-        <q-knob show-value class="text-white q-ma-md timer-knob" v-model="TIMER_VALUE" size="180px" :thickness="0.2"
-          color="green-4" :center-color="timer_finished ? 'green-4' : 'grey-6'" track-color="transparent" readonly="">
+      <div
+        class="col-6 row justify-center items-center"
+        style="position: relative"
+      >
+        <q-knob
+          show-value
+          class="text-white q-ma-md timer-knob"
+          v-model="TIMER_VALUE"
+          size="180px"
+          :thickness="0.2"
+          color="green-4"
+          :center-color="timer_finished ? 'green-4' : 'grey-6'"
+          track-color="transparent"
+          readonly=""
+        >
           <div class="text-center">
             <div>
-              {{ formatTime(time - progress) }}
-              <q-popup-edit v-if="!isActive" v-model="time" auto-save v-slot="scope">
-                <q-input v-model="scope.value" dense autofocus counter @keyup.enter="scope.set" />
+              {{ formatTime(time - timer.progress) }}
+              <q-popup-edit
+                v-if="!isActive"
+                v-model="time"
+                auto-save
+                v-slot="scope"
+              >
+                <q-input
+                  v-model="scope.value"
+                  dense
+                  autofocus
+                  counter
+                  @keyup.enter="scope.set"
+                />
               </q-popup-edit>
             </div>
             <div class="my-small-text">Sekunden</div>
           </div>
         </q-knob>
 
-        <q-btn flat round dense size="lg" icon="push_pin" :color="isPinned ? 'amber-7' : 'grey-6'" @click="togglePin"
-          class="absolute" style="top: 10px; right: 10px">
+        <q-btn
+          flat
+          round
+          dense
+          size="lg"
+          icon="push_pin"
+          :color="isPinned ? 'amber-7' : 'grey-6'"
+          @click="togglePin"
+          class="absolute"
+          style="top: 10px; right: 10px"
+        >
           <q-tooltip>Pin</q-tooltip>
         </q-btn>
       </div>
@@ -47,22 +97,61 @@
       <!-- BUTTONS -->
       <div class="col-1">
         <div class="row justify-center q-gutter-md" v-if="!isActive">
-          <q-btn class="my-decent-text" color="positive" @click="addTime(bigStep)" round>+{{ bigStep }}</q-btn>
-          <q-btn class="my-decent-text" color="positive" @click="addTime(1)" round>+1</q-btn>
-          <q-btn class="my-decent-text" color="negative" @click="addTime(-1)" round>-1</q-btn>
-          <q-btn class="my-decent-text" color="negative" @click="addTime(-bigStep)" round>-{{ bigStep }}</q-btn>
+          <q-btn
+            class="my-decent-text"
+            color="positive"
+            @click="addTime(bigStep)"
+            round
+            >+{{ bigStep }}</q-btn
+          >
+          <q-btn
+            class="my-decent-text"
+            color="positive"
+            @click="addTime(1)"
+            round
+            >+1</q-btn
+          >
+          <q-btn
+            class="my-decent-text"
+            color="negative"
+            @click="addTime(-1)"
+            round
+            >-1</q-btn
+          >
+          <q-btn
+            class="my-decent-text"
+            color="negative"
+            @click="addTime(-bigStep)"
+            round
+            >-{{ bigStep }}</q-btn
+          >
         </div>
       </div>
       <div class="col-2"></div>
     </div>
-    <div class="col-1 bottom-container fixed-bottom row justify-center items-center q-pa-sm"
-      v-if="store.pinnedTimers.length">
-      <q-btn v-for="t in store.pinnedTimers" :key="'p' + t" round size="sm" color="amber-7" class="q-mx-md" no-caps
-        @click="selectTime(t)">
+    <div
+      class="col-1 bottom-container fixed-bottom row justify-center items-center q-pa-sm"
+      v-if="store.pinnedTimers.length"
+    >
+      <q-btn
+        v-for="t in store.pinnedTimers"
+        :key="'p' + t"
+        round
+        size="sm"
+        color="amber-7"
+        class="q-mx-md"
+        no-caps
+        @click="selectTime(t)"
+      >
         {{ t }}s
       </q-btn>
 
-      <q-btn class="absolute-bottom-right" @click="store.removePinnedTimers()" icon="delete" round>
+      <q-btn
+        class="absolute-bottom-right"
+        @click="store.removePinnedTimers()"
+        icon="delete"
+        round
+      >
         <q-tooltip>Entferne alle voreingestellten Timer</q-tooltip>
       </q-btn>
     </div>
@@ -72,19 +161,14 @@
 <script>
 import { useAppStore } from "stores/appStore";
 import playSound from "src/tools/sound.js";
-import useTimer from "src/composables/useTimer";
+import { useTimerStore } from "stores/timerStore";
 export default {
   name: "QuickTimer",
   components: {},
   setup() {
     const store = useAppStore();
-    const {
-      start: startInterval,
-      stop: stopInterval,
-      progress,
-      isActive,
-    } = useTimer();
-    return { store, startInterval, stopInterval, progress, isActive };
+    const timer = useTimerStore();
+    return { store, timer };
   },
   data() {
     return {
@@ -92,11 +176,11 @@ export default {
       timer_finished: false,
     };
   },
-  mounted() { },
+  mounted() {},
 
   computed: {
     TIMER_VALUE() {
-      return (this.progress / this.time) * 100;
+      return (this.timer.progress / this.time) * 100;
     },
     bigStep() {
       return this.time >= 60 ? 10 : 5;
@@ -104,11 +188,27 @@ export default {
     isPinned() {
       return this.store.pinnedTimers.includes(this.time);
     },
+    isActive() {
+      return this.timer.running;
+    },
+  },
+
+  watch: {
+    "timer.finished"(val) {
+      this.timer_finished = val;
+      if (val) {
+        playSound("gong", this.store.settings.audio_playback);
+        this.store.setSettingsQuickTimerStartValue(this.time);
+        if (typeof this.store.addRecentTimer === "function") {
+          this.store.addRecentTimer(this.time);
+        }
+      }
+    },
   },
 
   methods: {
     goBack() {
-      this.stopInterval();
+      this.timer.stop();
       this.$router.go(-1);
     },
 
@@ -131,27 +231,13 @@ export default {
 
     // TIMER
     startTimer() {
-      // value is the actual value of the timer
-      // time is the time in seconds
-      // timeLeft is the time left in seconds
       playSound("gong", this.store.settings.audio_playback);
       this.timer_finished = false;
-      let timeLeft = this.time;
-      this.progress = 0;
-      this.startInterval(() => {
-        timeLeft = timeLeft - 1;
-        if (timeLeft <= 0) {
-          playSound("gong", this.store.settings.audio_playback);
-          this.stopInterval();
-          this.timer_finished = true;
-          this.store.setSettingsQuickTimerStartValue(this.time);
-          this.store.addRecentTimer(this.time);
-        }
-      });
+      this.timer.start(this.time);
     },
 
     stopTimer() {
-      this.stopInterval();
+      this.timer.stop();
       this.timer_finished = false;
     },
     selectTime(t) {

--- a/src/stores/timerStore.js
+++ b/src/stores/timerStore.js
@@ -1,0 +1,42 @@
+import { defineStore } from "pinia";
+
+export const useTimerStore = defineStore("timer", {
+  state: () => ({
+    duration: 0,
+    progress: 0,
+    running: false,
+    finished: false,
+    _interval: null,
+  }),
+  actions: {
+    start(duration) {
+      this.stop();
+      this.duration = duration;
+      this.progress = 0;
+      this.finished = false;
+      this.running = true;
+      this._interval = setInterval(() => {
+        this.tick();
+      }, 1000);
+    },
+    tick() {
+      this.progress += 1;
+      if (this.progress >= this.duration) {
+        this.stop(false);
+        this.finished = true;
+        this.progress = 0;
+      }
+    },
+    stop(reset = true) {
+      if (this._interval) {
+        clearInterval(this._interval);
+        this._interval = null;
+      }
+      this.running = false;
+      if (reset) {
+        this.progress = 0;
+        this.finished = false;
+      }
+    },
+  },
+});

--- a/test/jest/__tests__/QuickTimer.spec.js
+++ b/test/jest/__tests__/QuickTimer.spec.js
@@ -1,77 +1,90 @@
-import { beforeEach, afterEach, describe, it, expect, jest } from '@jest/globals'
-import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest'
-import { shallowMount } from '@vue/test-utils'
-import { createPinia, setActivePinia } from 'pinia'
-jest.mock('src/tools/sound.js', () => ({ __esModule: true, default: jest.fn() }))
-import QuickTimer from 'pages/Timer/QuickTimer.vue'
-import { useAppStore } from 'stores/appStore'
+import {
+  beforeEach,
+  afterEach,
+  describe,
+  it,
+  expect,
+  jest,
+} from "@jest/globals";
+import { installQuasarPlugin } from "@quasar/quasar-app-extension-testing-unit-jest";
+import { shallowMount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+jest.mock("src/tools/sound.js", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+import QuickTimer from "pages/Timer/QuickTimer.vue";
+import { useAppStore } from "stores/appStore";
+import { useTimerStore } from "stores/timerStore";
 
-installQuasarPlugin()
+installQuasarPlugin();
 
-describe('QuickTimer', () => {
-  let wrapper
-  let store
+describe("QuickTimer", () => {
+  let wrapper;
+  let store;
+  let timer;
 
   beforeEach(() => {
-    jest.useFakeTimers()
-    const pinia = createPinia()
-    setActivePinia(pinia)
-    localStorage.clear()
-    store = useAppStore()
+    jest.useFakeTimers();
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    localStorage.clear();
+    store = useAppStore();
+    timer = useTimerStore();
     // store no longer provides addRecentTimer, stub to avoid test errors
-    store.addRecentTimer = jest.fn()
+    store.addRecentTimer = jest.fn();
     wrapper = shallowMount(QuickTimer, {
       global: {
         plugins: [pinia],
         mocks: { $router: { go: jest.fn() } },
         stubs: {
-          'q-page': true,
-          'q-btn': true,
-          'q-knob': true,
-          'q-popup-edit': true,
-          'q-input': true
-        }
-      }
-    })
-  })
+          "q-page": true,
+          "q-btn": true,
+          "q-knob": true,
+          "q-popup-edit": true,
+          "q-input": true,
+        },
+      },
+    });
+  });
 
   afterEach(() => {
-    jest.useRealTimers()
-  })
+    jest.useRealTimers();
+  });
 
-  it('counts down and resets when finished', async () => {
-    wrapper.vm.time = 1
-    wrapper.vm.startTimer()
-    expect(wrapper.vm.isActive).toBe(true)
-    jest.advanceTimersByTime(1000)
-    await wrapper.vm.$nextTick()
-    expect(wrapper.vm.timer_finished).toBe(true)
-    expect(wrapper.vm.progress).toBe(0)
-    expect(wrapper.vm.isActive).toBe(false)
-  })
+  it("counts down and resets when finished", async () => {
+    wrapper.vm.time = 1;
+    wrapper.vm.startTimer();
+    expect(wrapper.vm.isActive).toBe(true);
+    jest.advanceTimersByTime(1000);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.timer_finished).toBe(true);
+    expect(timer.progress).toBe(0);
+    expect(wrapper.vm.isActive).toBe(false);
+  });
 
-  it('stopTimer resets state', () => {
-    wrapper.vm.time = 5
-    wrapper.vm.startTimer()
-    jest.advanceTimersByTime(1000)
-    wrapper.vm.stopTimer()
-    expect(wrapper.vm.isActive).toBe(false)
-    expect(wrapper.vm.timer_finished).toBe(false)
-    expect(wrapper.vm.progress).toBe(0)
-  })
+  it("stopTimer resets state", () => {
+    wrapper.vm.time = 5;
+    wrapper.vm.startTimer();
+    jest.advanceTimersByTime(1000);
+    wrapper.vm.stopTimer();
+    expect(wrapper.vm.isActive).toBe(false);
+    expect(wrapper.vm.timer_finished).toBe(false);
+    expect(timer.progress).toBe(0);
+  });
 
-  it('updates step size when timer exceeds 60 seconds', () => {
-    wrapper.vm.time = 55
-    expect(wrapper.vm.bigStep).toBe(5)
-    wrapper.vm.time = 65
-    expect(wrapper.vm.bigStep).toBe(10)
-  })
+  it("updates step size when timer exceeds 60 seconds", () => {
+    wrapper.vm.time = 55;
+    expect(wrapper.vm.bigStep).toBe(5);
+    wrapper.vm.time = 65;
+    expect(wrapper.vm.bigStep).toBe(10);
+  });
 
-  it('togglePin pins and unpins the current timer', () => {
-    wrapper.vm.time = 5
-    wrapper.vm.togglePin()
-    expect(store.pinnedTimers).toContain(5)
-    wrapper.vm.togglePin()
-    expect(store.pinnedTimers).not.toContain(5)
-  })
-})
+  it("togglePin pins and unpins the current timer", () => {
+    wrapper.vm.time = 5;
+    wrapper.vm.togglePin();
+    expect(store.pinnedTimers).toContain(5);
+    wrapper.vm.togglePin();
+    expect(store.pinnedTimers).not.toContain(5);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `useTimerStore` for managing timer state
- refactor QuickTimer component to use the new store
- update QuickTimer unit tests to reflect store usage

## Testing
- `npx prettier src/stores/timerStore.js src/pages/Timer/QuickTimer.vue test/jest/__tests__/QuickTimer.spec.js --write`
- `npx eslint src/stores/timerStore.js src/pages/Timer/QuickTimer.vue test/jest/__tests__/QuickTimer.spec.js`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6876233ee9f8832283c2f53036eab292