### PR TITLE
Create dedicated program store

### DIFF
--- a/src/pages/Timer/ProgrammTimer.vue
+++ b/src/pages/Timer/ProgrammTimer.vue
@@ -209,6 +209,7 @@ import MY_ITEM_BTN from "components/MyItemBtn.vue";
 import DurationSlider from "components/DurationSlider.vue";
 import getRandomCitation from "src/tools/citate.js";
 import { useAppStore } from "stores/appStore";
+import { useProgramStore } from "stores/programStore";
 import playSound from "src/tools/sound.js";
 import useTimer from "src/composables/useTimer";
 
@@ -220,21 +221,29 @@ export default {
   },
   setup() {
     const store = useAppStore();
+    const programStore = useProgramStore();
     const {
       start: startInterval,
       stop: stopInterval,
       progress,
       isActive,
     } = useTimer();
-    return { store, startInterval, stopInterval, progress, isActive };
+    return {
+      store,
+      programStore,
+      startInterval,
+      stopInterval,
+      progress,
+      isActive,
+    };
   },
   data() {
     return {
       timer_finished: false,
       timer_halted: false,
       localData: {
-        ...JSON.parse(JSON.stringify(this.store.lastPreset)),
-        exerciseNames: this.store.lastPreset.exerciseNames || [],
+        ...JSON.parse(JSON.stringify(this.programStore.lastPreset)),
+        exerciseNames: this.programStore.lastPreset.exerciseNames || [],
       },
       // progress state handled by composable
       TIME_DATA: undefined,
@@ -251,12 +260,12 @@ export default {
     };
   },
   mounted() {
-    this.store.PROGRAM_STEPS = [];
+    this.programStore.PROGRAM_STEPS = [];
   },
 
   computed: {
     programSteps() {
-      return this.store.programSteps;
+      return this.programStore.programSteps;
     },
 
     STEP_OPTIONS() {
@@ -324,7 +333,7 @@ export default {
     },
 
     PRESETS() {
-      return this.store.presets;
+      return this.programStore.presets;
     },
 
     PRESET_LABEL() {
@@ -390,7 +399,7 @@ export default {
     },
 
     addPreset() {
-      this.localData = JSON.parse(JSON.stringify(this.store.lastPreset));
+      this.localData = JSON.parse(JSON.stringify(this.programStore.lastPreset));
       this.localData.label = this.label_new_preset;
     },
 
@@ -406,7 +415,7 @@ export default {
         })
         .onOk(() => {
           // remove preset
-          this.store.removePreset(label);
+          this.programStore.removePreset(label);
           this.localData.label = "Letztes Programm";
         });
     },
@@ -414,7 +423,7 @@ export default {
     selectPreset(preset) {
       if (preset.data === undefined) {
         // load last workout
-        this.localData = JSON.parse(JSON.stringify(this.store.lastPreset));
+        this.localData = JSON.parse(JSON.stringify(this.programStore.lastPreset));
         return;
       } else {
         this.localData.action.value = preset.data.action.value;
@@ -443,7 +452,7 @@ export default {
           // save preset
           const input = data.trim();
           // check if name already exists
-          const preset_exists = this.store.presets.find(
+          const preset_exists = this.programStore.presets.find(
             (preset) =>
               preset.label.trim().toLowerCase() === input.toLowerCase()
           );
@@ -480,12 +489,12 @@ export default {
               },
             },
           };
-          this.store.addPreset(new_preset);
+          this.programStore.addPreset(new_preset);
         });
     },
 
     removeStep(index) {
-      this.store.removeProgramStep(index);
+      this.programStore.removeProgramStep(index);
     },
 
     openStepDurationDialog(idx) {
@@ -526,7 +535,7 @@ export default {
           });
         }
       }
-      this.store.PROGRAM_STEPS = steps;
+      this.programStore.PROGRAM_STEPS = steps;
     },
 
     onDragStart(idx) {
@@ -535,7 +544,7 @@ export default {
 
     onDrop(idx) {
       if (this.dragIndex === null) return;
-      this.store.moveProgramStep(this.dragIndex, idx);
+      this.programStore.moveProgramStep(this.dragIndex, idx);
       this.dragIndex = null;
     },
 
@@ -549,7 +558,7 @@ export default {
       playSound("beepbeepbeep_1s", this.store.settings.audio_playback);
       await this.delay(1500);
 
-      this.store.setLastPreset(JSON.parse(JSON.stringify(this.localData)));
+      this.programStore.setLastPreset(JSON.parse(JSON.stringify(this.localData)));
 
       // start timer
       this.nextTimer();

--- a/src/stores/appStore.js
+++ b/src/stores/appStore.js
@@ -1,56 +1,7 @@
 import { defineStore } from "pinia";
 
-const templatePresets = [
-  { label: "letztes Workout laden", data: undefined },
-  {
-    label: "Tabata",
-    data: {
-      action: { value: 30 },
-      break: { value: 5 },
-      exercises: { value: 4 },
-      rounds: { value: 5 },
-      round_break: { value: 15 },
-    },
-  },
-  {
-    label: "Ohio",
-    data: {
-      action: { value: 30 },
-      break: { value: 5 },
-      exercises: { value: 3 },
-      rounds: { value: 3 },
-      round_break: { value: 5 },
-    },
-  },
-];
-
-const defaultPreset = {
-  action: { value: 5, unit: "s" },
-  break: { value: 2, unit: "s" },
-  exercises: { value: 2, unit: "x" },
-  rounds: { value: 2, unit: "x" },
-  round_break: { value: 10, unit: "s" },
-  label: "Default",
-};
-
 export const useAppStore = defineStore("app", {
   state: () => {
-    let lastPreset;
-    try {
-      const rawLastPreset = localStorage.getItem("last_preset");
-      if (rawLastPreset !== null) lastPreset = JSON.parse(rawLastPreset);
-    } catch (e) {
-      lastPreset = undefined;
-    }
-
-    let presets;
-    try {
-      const rawPresets = localStorage.getItem("presets");
-      if (rawPresets !== null) presets = JSON.parse(rawPresets);
-    } catch (e) {
-      presets = null;
-    }
-
     let pinnedTimers;
     try {
       const rawPinned = localStorage.getItem("pinned_timers");
@@ -64,9 +15,6 @@ export const useAppStore = defineStore("app", {
         audio_playback: true,
         quick_timer_start_value: 20, // in seconds
       },
-      LAST_PRESET: lastPreset || undefined,
-      PRESETS: presets || templatePresets,
-      PROGRAM_STEPS: [],
       PINNED_TIMERS: pinnedTimers || [],
       essentialLinks: [
         { titel: "Home", caption: "zurück", icon: "home", route: "Index" },
@@ -90,9 +38,6 @@ export const useAppStore = defineStore("app", {
       APP_NAME: process.env.APP_NAME,
     }),
     settings: (state) => state.SETTINGS,
-    lastPreset: (state) => state.LAST_PRESET || defaultPreset,
-    presets: (state) => state.PRESETS,
-    programSteps: (state) => state.PROGRAM_STEPS,
     pinnedTimers: (state) => state.PINNED_TIMERS,
   },
   actions: {
@@ -101,24 +46,6 @@ export const useAppStore = defineStore("app", {
     },
     setSettingsQuickTimerStartValue(payload) {
       this.SETTINGS.quick_timer_start_value = payload;
-    },
-    setLastPreset(payload) {
-      console.log({ message: "SET_LAST_PRESET" });
-      window.localStorage.setItem("last_preset", JSON.stringify(payload));
-      this.LAST_PRESET = payload;
-    },
-    addPreset(payload) {
-      console.log({ message: "ADD_PRESET" });
-      this.PRESETS.push(payload);
-      window.localStorage.setItem("presets", JSON.stringify(this.PRESETS));
-    },
-    removePreset(label) {
-      console.log({ message: "REMOVE_PRESET" });
-      const target = label.trim().toLowerCase();
-      this.PRESETS = this.PRESETS.filter(
-        (preset) => preset.label.trim().toLowerCase() !== target
-      );
-      window.localStorage.setItem("presets", JSON.stringify(this.PRESETS));
     },
 
     pinTimer(duration) {
@@ -146,19 +73,6 @@ export const useAppStore = defineStore("app", {
         "pinned_timers",
         JSON.stringify(this.PINNED_TIMERS)
       );
-    },
-    removeProgramStep(index) {
-      this.PROGRAM_STEPS.splice(index, 1);
-    },
-    moveProgramStep(from, to) {
-      const item = this.PROGRAM_STEPS.splice(from, 1)[0];
-      this.PROGRAM_STEPS.splice(to, 0, item);
-    },
-    updateProgramStep(index, partial) {
-      this.PROGRAM_STEPS[index] = {
-        ...this.PROGRAM_STEPS[index],
-        ...partial,
-      };
     },
     log(payload) {
       console.log(payload);

--- a/src/stores/programStore.js
+++ b/src/stores/programStore.js
@@ -1,0 +1,95 @@
+import { defineStore } from "pinia";
+
+const templatePresets = [
+  { label: "letztes Workout laden", data: undefined },
+  {
+    label: "Tabata",
+    data: {
+      action: { value: 30 },
+      break: { value: 5 },
+      exercises: { value: 4 },
+      rounds: { value: 5 },
+      round_break: { value: 15 },
+    },
+  },
+  {
+    label: "Ohio",
+    data: {
+      action: { value: 30 },
+      break: { value: 5 },
+      exercises: { value: 3 },
+      rounds: { value: 3 },
+      round_break: { value: 5 },
+    },
+  },
+];
+
+const defaultPreset = {
+  action: { value: 5, unit: "s" },
+  break: { value: 2, unit: "s" },
+  exercises: { value: 2, unit: "x" },
+  rounds: { value: 2, unit: "x" },
+  round_break: { value: 10, unit: "s" },
+  label: "Default",
+};
+
+export const useProgramStore = defineStore("program", {
+  state: () => {
+    let lastPreset;
+    try {
+      const rawLastPreset = localStorage.getItem("last_preset");
+      if (rawLastPreset !== null) lastPreset = JSON.parse(rawLastPreset);
+    } catch (e) {
+      lastPreset = undefined;
+    }
+
+    let presets;
+    try {
+      const rawPresets = localStorage.getItem("presets");
+      if (rawPresets !== null) presets = JSON.parse(rawPresets);
+    } catch (e) {
+      presets = null;
+    }
+
+    return {
+      LAST_PRESET: lastPreset || undefined,
+      PRESETS: presets || templatePresets,
+      PROGRAM_STEPS: [],
+    };
+  },
+  getters: {
+    lastPreset: (state) => state.LAST_PRESET || defaultPreset,
+    presets: (state) => state.PRESETS,
+    programSteps: (state) => state.PROGRAM_STEPS,
+  },
+  actions: {
+    setLastPreset(payload) {
+      localStorage.setItem("last_preset", JSON.stringify(payload));
+      this.LAST_PRESET = payload;
+    },
+    addPreset(payload) {
+      this.PRESETS.push(payload);
+      localStorage.setItem("presets", JSON.stringify(this.PRESETS));
+    },
+    removePreset(label) {
+      const target = label.trim().toLowerCase();
+      this.PRESETS = this.PRESETS.filter(
+        (preset) => preset.label.trim().toLowerCase() !== target
+      );
+      localStorage.setItem("presets", JSON.stringify(this.PRESETS));
+    },
+    removeProgramStep(index) {
+      this.PROGRAM_STEPS.splice(index, 1);
+    },
+    moveProgramStep(from, to) {
+      const item = this.PROGRAM_STEPS.splice(from, 1)[0];
+      this.PROGRAM_STEPS.splice(to, 0, item);
+    },
+    updateProgramStep(index, partial) {
+      this.PROGRAM_STEPS[index] = {
+        ...this.PROGRAM_STEPS[index],
+        ...partial,
+      };
+    },
+  },
+});

--- a/test/jest/__tests__/ProgramTimer.spec.js
+++ b/test/jest/__tests__/ProgramTimer.spec.js
@@ -15,19 +15,22 @@ jest.mock("src/tools/sound.js", () => ({
 }));
 import ProgramTimer from "pages/Timer/ProgrammTimer.vue";
 import { useAppStore } from "stores/appStore";
+import { useProgramStore } from "stores/programStore";
 
 installQuasarPlugin();
 
 describe("ProgramTimer", () => {
   let wrapper;
-  let store;
+  let appStore;
+  let programStore;
 
   beforeEach(() => {
     jest.useFakeTimers();
     const pinia = createPinia();
     setActivePinia(pinia);
-    store = useAppStore();
-    store.PROGRAM_STEPS = [{ type: "action", duration: 1, repetitions: 1 }];
+    appStore = useAppStore();
+    programStore = useProgramStore();
+    programStore.PROGRAM_STEPS = [{ type: "action", duration: 1, repetitions: 1 }];
     wrapper = shallowMount(ProgramTimer, {
       global: {
         plugins: [pinia],
@@ -85,7 +88,7 @@ describe("ProgramTimer", () => {
     wrapper.vm.localData.round_break.value = 0;
     wrapper.vm.localData.exerciseNames = ["a", "b"];
     wrapper.vm.generateStepsFromSettings();
-    expect(store.programSteps).toEqual([
+    expect(programStore.programSteps).toEqual([
       { type: "action", duration: 2, repetitions: 1, name: "a" },
       { type: "break", duration: 1, repetitions: 1 },
       { type: "action", duration: 2, repetitions: 1, name: "b" },
@@ -93,7 +96,7 @@ describe("ProgramTimer", () => {
   });
 
   it("prepares timer data including names", () => {
-    store.PROGRAM_STEPS = [
+    programStore.PROGRAM_STEPS = [
       { type: "action", duration: 1, repetitions: 1, name: "x" },
     ];
     const times = wrapper.vm._prepareTimer();
@@ -104,7 +107,7 @@ describe("ProgramTimer", () => {
     const pinia = createPinia();
     setActivePinia(pinia);
     localStorage.clear();
-    const localStore = useAppStore();
+    const localStore = useProgramStore();
     const altWrapper = shallowMount(ProgramTimer, {
       global: {
         plugins: [pinia],
@@ -136,7 +139,7 @@ describe("ProgramTimer", () => {
   });
 
   it("updates program when preset is selected", async () => {
-    const preset = store.presets.find((p) => p.data);
+    const preset = programStore.presets.find((p) => p.data);
     wrapper.vm.selectPreset(preset);
     await wrapper.vm.$nextTick();
     expect(wrapper.vm.DURATION_CALC).toBe(wrapper.vm.calcDuration(preset.data));

--- a/test/jest/__tests__/appStore.spec.js
+++ b/test/jest/__tests__/appStore.spec.js
@@ -27,10 +27,4 @@ describe("appStore pinning", () => {
     expect(store.pinnedTimers).toEqual([20]);
   });
 
-  it("removePreset ignores surrounding spaces", () => {
-    const initial = store.presets.length;
-    store.removePreset("  Tabata  ");
-    expect(store.presets.length).toBe(initial - 1);
-    expect(store.presets.some((p) => p.label === "Tabata")).toBe(false);
-  });
 });

--- a/test/jest/__tests__/programStore.spec.js
+++ b/test/jest/__tests__/programStore.spec.js
@@ -1,0 +1,20 @@
+import { beforeEach, describe, it, expect } from "@jest/globals";
+import { createPinia, setActivePinia } from "pinia";
+import { useProgramStore } from "stores/programStore";
+
+describe("programStore", () => {
+  let store;
+  beforeEach(() => {
+    localStorage.clear();
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    store = useProgramStore();
+  });
+
+  it("removePreset ignores surrounding spaces", () => {
+    const initial = store.presets.length;
+    store.removePreset("  Tabata  ");
+    expect(store.presets.length).toBe(initial - 1);
+    expect(store.presets.some((p) => p.label === "Tabata")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add programStore for presets and program steps
- remove preset logic from appStore
- update ProgramTimer to use the new store
- adjust tests for programStore separation

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6876260595a0832282fd291047e98806