### PR TITLE
Add reusable dialog

### DIFF
--- a/src/components/BaseDialog.vue
+++ b/src/components/BaseDialog.vue
@@ -1,0 +1,24 @@
+<template>
+  <q-dialog v-model="modelValue">
+    <q-card class="my-popup-card text-center white-shadow">
+      <q-card-section v-if="title">{{ title }}</q-card-section>
+      <slot />
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+  modelValue: Boolean,
+  title: String,
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+const modelValue = computed({
+  get: () => props.modelValue,
+  set: (val) => emit("update:modelValue", val),
+});
+</script>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -65,6 +65,10 @@ body {
   color: $light;
 }
 
+.white-shadow {
+  box-shadow: 0 0 8px white;
+}
+
 @media (min-width: 401px) {
   h1,
   .text-h1 {

--- a/src/pages/Timer/ProgrammTimer.vue
+++ b/src/pages/Timer/ProgrammTimer.vue
@@ -1,19 +1,50 @@
 <template>
   <q-page data-cy="page_about" class="full-height">
-    <q-btn icon="close" size="lg" flat round class="absolute-top-right" @click="goBack()" />
-    <q-btn :icon="!store.settings.audio_playback ? 'volume_off' : 'volume_up'" size="lg" flat round
-      class="absolute-top-left" @click="store.setSettingsAudioPlayback(!store.settings.audio_playback)" />
+    <q-btn
+      icon="close"
+      size="lg"
+      flat
+      round
+      class="absolute-top-right"
+      @click="goBack()"
+    />
+    <q-btn
+      :icon="!store.settings.audio_playback ? 'volume_off' : 'volume_up'"
+      size="lg"
+      flat
+      round
+      class="absolute-top-left"
+      @click="store.setSettingsAudioPlayback(!store.settings.audio_playback)"
+    />
     <div class="column text-center" style="height: 100vh; width: 100vw">
       <div class="col-1">Program</div>
       <!-- TIMER ELEMENT -->
       <!-- BTN -->
       <div class="col-2">
-        <MY_ITEM_BTN v-if="!isActive && timer_halted === false" :label="'START'" :icon="'play_arrow'"
-          @clicked="startTimer()" />
-        <MY_ITEM_BTN v-if="!isActive && timer_halted === true" :label="'ABBRECHEN'" :icon="'close'"
-          @clicked="clearTimer()" />
-        <MY_ITEM_BTN v-if="isActive && !timer_finished" :label="'STOP'" :icon="'stop'" @clicked="stopTimer()" />
-        <MY_ITEM_BTN v-if="isActive && timer_finished" :label="'ZURÜCK'" :icon="'arrow_back'" @clicked="clearTimer()" />
+        <MY_ITEM_BTN
+          v-if="!isActive && timer_halted === false"
+          :label="'START'"
+          :icon="'play_arrow'"
+          @clicked="startTimer()"
+        />
+        <MY_ITEM_BTN
+          v-if="!isActive && timer_halted === true"
+          :label="'ABBRECHEN'"
+          :icon="'close'"
+          @clicked="clearTimer()"
+        />
+        <MY_ITEM_BTN
+          v-if="isActive && !timer_finished"
+          :label="'STOP'"
+          :icon="'stop'"
+          @clicked="stopTimer()"
+        />
+        <MY_ITEM_BTN
+          v-if="isActive && timer_finished"
+          :label="'ZURÜCK'"
+          :icon="'arrow_back'"
+          @clicked="clearTimer()"
+        />
       </div>
 
       <!-- DURATION -->
@@ -28,26 +59,45 @@
       <!-- OPTIONS -->
       <div v-if="!isActive && timer_halted === false" class="col">
         <!-- STEUER ELEMENTE -->
-        <div class="row q-gutter-y-sm justify-center" style="width: 100vw; max-width: 1000px">
+        <div
+          class="row q-gutter-y-sm justify-center"
+          style="width: 100vw; max-width: 1000px"
+        >
           <!-- SELECTION / PREVIOUS -->
           <div class="col-12">
             <q-item clickable v-ripple class="q-ma-sm">
               <q-item-section avatar><q-icon name="today" /></q-item-section>
               <q-item-section>
-                <q-btn flat no-caps @click="showPresetDialog = true">{{ PRESET_LABEL }}</q-btn>
+                <q-btn flat no-caps @click="showPresetDialog = true">{{
+                  PRESET_LABEL
+                }}</q-btn>
                 <ProgramSelectDialog
                   v-model="showPresetDialog"
                   :current-settings="localData"
                   @select="selectPreset"
                 />
               </q-item-section>
-              <q-item-section side v-if="localData.label === label_new_preset"><q-btn flat icon="save"
-                  @click="saveNewPreset()" color="white"></q-btn></q-item-section>
-              <q-item-section side v-else-if="
-                localData.label !== label_new_preset &&
-                localData.label !== 'Default'
-              "><q-btn flat icon="delete" @click="removePreset(this.localData.label)"
-                  color="grey-5"></q-btn></q-item-section>
+              <q-item-section side v-if="localData.label === label_new_preset"
+                ><q-btn
+                  flat
+                  icon="save"
+                  @click="saveNewPreset()"
+                  color="white"
+                ></q-btn
+              ></q-item-section>
+              <q-item-section
+                side
+                v-else-if="
+                  localData.label !== label_new_preset &&
+                  localData.label !== 'Default'
+                "
+                ><q-btn
+                  flat
+                  icon="delete"
+                  @click="removePreset(this.localData.label)"
+                  color="grey-5"
+                ></q-btn
+              ></q-item-section>
             </q-item>
           </div>
 
@@ -57,99 +107,155 @@
               <q-icon name="play_circle" class="q-mr-sm" />Action:
               {{ formatTime(localData.action.value) }}
             </q-btn>
-            <q-dialog v-model="showActionDialog">
-              <q-card class="my-popup-card text-center shadow-1">
-                <q-card-section>Action anpassen</q-card-section>
-                <q-card-section>
-                  <DurationSlider v-model="localData.action.value" :min="5" :max="3600" :step="5" />
-                </q-card-section>
-              </q-card>
-            </q-dialog>
+            <BaseDialog v-model="showActionDialog" title="Action anpassen">
+              <q-card-section>
+                <DurationSlider
+                  v-model="localData.action.value"
+                  :min="5"
+                  :max="3600"
+                  :step="5"
+                />
+              </q-card-section>
+            </BaseDialog>
           </div>
 
           <!-- Pause -->
           <div class="col-12">
-            <q-btn no-caps class="my-main-btn" color="negative" @click="showBreakDialog = true">
+            <q-btn
+              no-caps
+              class="my-main-btn"
+              color="negative"
+              @click="showBreakDialog = true"
+            >
               <q-icon name="pause_circle" class="q-mr-sm" />Pause:
               {{ formatTime(localData.break.value) }}
             </q-btn>
-            <q-dialog v-model="showBreakDialog">
-              <q-card class="my-popup-card text-center shadow-1">
-                <q-card-section>Pause anpassen</q-card-section>
-                <q-card-section>
-                  <DurationSlider v-model="localData.break.value" :min="0" :max="3600" :step="5" />
-                </q-card-section>
-              </q-card>
-            </q-dialog>
+            <BaseDialog v-model="showBreakDialog" title="Pause anpassen">
+              <q-card-section>
+                <DurationSlider
+                  v-model="localData.break.value"
+                  :min="0"
+                  :max="3600"
+                  :step="5"
+                />
+              </q-card-section>
+            </BaseDialog>
           </div>
 
           <!-- Excercises -->
           <div class="col-12">
-            <q-btn no-caps class="my-main-btn" color="secondary" @click="showExerciseDialog = true">
+            <q-btn
+              no-caps
+              class="my-main-btn"
+              color="secondary"
+              @click="showExerciseDialog = true"
+            >
               <q-icon name="fitness_center" class="q-mr-sm" />Übungen:
               {{ localData.exercises.value }} {{ localData.exercises.unit }}
             </q-btn>
-            <q-dialog v-model="showExerciseDialog">
-              <q-card class="my-popup-card text-center shadow-1">
-                <q-card-section>Übungen anpassen</q-card-section>
-                <q-card-section>
-                  <q-slider v-model="localData.exercises.value" label label-text-color="dark" color="white"
-                    thumb-size="50px" :step="1" :min="1" :max="50" />
-                </q-card-section>
-                <q-card-section v-if="localData.exercises.value > 1">
-                  <div class="q-gutter-sm">
-                    <q-input v-for="n in localData.exercises.value" :key="'name' + n" dense type="text"
-                      :label="'Übung ' + n" v-model="localData.exerciseNames[n - 1]" />
-                  </div>
-                </q-card-section>
-              </q-card>
-            </q-dialog>
+            <BaseDialog v-model="showExerciseDialog" title="Übungen anpassen">
+              <q-card-section>
+                <q-slider
+                  v-model="localData.exercises.value"
+                  label
+                  label-text-color="dark"
+                  color="white"
+                  thumb-size="50px"
+                  :step="1"
+                  :min="1"
+                  :max="50"
+                />
+              </q-card-section>
+              <q-card-section v-if="localData.exercises.value > 1">
+                <div class="q-gutter-sm">
+                  <q-input
+                    v-for="n in localData.exercises.value"
+                    :key="'name' + n"
+                    dense
+                    type="text"
+                    :label="'Übung ' + n"
+                    v-model="localData.exerciseNames[n - 1]"
+                  />
+                </div>
+              </q-card-section>
+            </BaseDialog>
           </div>
 
           <q-separator class="q-my-md" />
 
           <!-- Repetitions -->
           <div class="col-12">
-            <q-btn no-caps class="my-main-btn" color="secondary" @click="showRoundsDialog = true">
+            <q-btn
+              no-caps
+              class="my-main-btn"
+              color="secondary"
+              @click="showRoundsDialog = true"
+            >
               <q-icon name="restart_alt" class="q-mr-sm" />Wiederholungen:
               {{ localData.rounds.value }} {{ localData.rounds.unit }}
             </q-btn>
-            <q-dialog v-model="showRoundsDialog">
-              <q-card class="my-popup-card text-center shadow-1">
-                <q-card-section>Wiederholungen anpassen</q-card-section>
-                <q-card-section>
-                  <q-slider v-model="localData.rounds.value" label label-text-color="dark" color="white"
-                    thumb-size="50px" :step="1" :min="1" :max="50" />
-                </q-card-section>
-              </q-card>
-            </q-dialog>
+            <BaseDialog
+              v-model="showRoundsDialog"
+              title="Wiederholungen anpassen"
+            >
+              <q-card-section>
+                <q-slider
+                  v-model="localData.rounds.value"
+                  label
+                  label-text-color="dark"
+                  color="white"
+                  thumb-size="50px"
+                  :step="1"
+                  :min="1"
+                  :max="50"
+                />
+              </q-card-section>
+            </BaseDialog>
           </div>
 
           <!-- BREAKS -->
           <div class="col-12">
-            <q-btn no-caps class="my-main-btn" color="negative" @click="showRoundBreakDialog = true">
+            <q-btn
+              no-caps
+              class="my-main-btn"
+              color="negative"
+              @click="showRoundBreakDialog = true"
+            >
               <q-icon name="restore" class="q-mr-sm" />Rundenpause:
               {{ formatTime(localData.round_break.value) }}
             </q-btn>
-            <q-dialog v-model="showRoundBreakDialog">
-              <q-card class="my-popup-card text-center shadow-1">
-                <q-card-section>Rundenpause anpassen</q-card-section>
-                <q-card-section>
-                  <DurationSlider v-model="localData.round_break.value" :min="0" :max="3600" :step="5" />
-                </q-card-section>
-              </q-card>
-            </q-dialog>
+            <BaseDialog
+              v-model="showRoundBreakDialog"
+              title="Rundenpause anpassen"
+            >
+              <q-card-section>
+                <DurationSlider
+                  v-model="localData.round_break.value"
+                  :min="0"
+                  :max="3600"
+                  :step="5"
+                />
+              </q-card-section>
+            </BaseDialog>
           </div>
 
           <q-separator class="q-my-md" />
-
         </div>
       </div>
 
       <!-- TIMER -->
       <div v-else class="col-2">
-        <q-knob show-value class="text-white q-ma-md" v-model="TIMER_PERCENTAGE" size="150px" :thickness="0.2"
-          color="grey-3" :center-color="TIMER_COLOR" track-color="transparent" readonly="">
+        <q-knob
+          show-value
+          class="text-white q-ma-md"
+          v-model="TIMER_PERCENTAGE"
+          size="150px"
+          :thickness="0.2"
+          color="grey-3"
+          :center-color="TIMER_COLOR"
+          track-color="transparent"
+          readonly=""
+        >
           <div v-if="timer_finished === true">
             <span style="font-size: 3em">🥇</span>
           </div>
@@ -159,7 +265,7 @@
                 {{ formatTime(TIMER_VALUE) }}
                 <q-tooltip v-if="TIME_DATA[TIME_IND].name">{{
                   TIME_DATA[TIME_IND].name
-                  }}</q-tooltip>
+                }}</q-tooltip>
               </div>
               <div class="text-caption">{{ TIMER_TYPE }}</div>
             </div>
@@ -170,15 +276,23 @@
         </q-knob>
 
         <div v-if="TIME_DATA && TIME_DATA[TIME_IND] && !timer_halted">
-          <q-chip>Schritt: {{ TIME_DATA[TIME_IND].step_ind + 1 }} /
-            {{ programSteps.length }}</q-chip>
-          <q-chip>Wdh.: {{ TIME_DATA[TIME_IND].rep_ind + 1 }} /
+          <q-chip
+            >Schritt: {{ TIME_DATA[TIME_IND].step_ind + 1 }} /
+            {{ programSteps.length }}</q-chip
+          >
+          <q-chip
+            >Wdh.: {{ TIME_DATA[TIME_IND].rep_ind + 1 }} /
             {{
               programSteps[TIME_DATA[TIME_IND].step_ind].repetitions || 1
-            }}</q-chip>
+            }}</q-chip
+          >
         </div>
         <div v-else-if="TIME_DATA && TIME_DATA[TIME_IND] && timer_halted">
-          <MY_ITEM_BTN :label="'WEITER'" :icon="'play_arrow'" @clicked="proceedTimer()" />
+          <MY_ITEM_BTN
+            :label="'WEITER'"
+            :icon="'play_arrow'"
+            @clicked="proceedTimer()"
+          />
         </div>
         <div v-else-if="timer_finished" class="text-orange-4">
           <div>
@@ -199,6 +313,7 @@
 import MY_ITEM_BTN from "components/MyItemBtn.vue";
 import DurationSlider from "components/DurationSlider.vue";
 import ProgramSelectDialog from "components/ProgramSelectDialog.vue";
+import BaseDialog from "components/BaseDialog.vue";
 import getRandomCitation from "src/tools/citate.js";
 import { useAppStore } from "stores/appStore";
 import { useProgramStore } from "stores/programStore";
@@ -211,6 +326,7 @@ export default {
     MY_ITEM_BTN,
     DurationSlider,
     ProgramSelectDialog,
+    BaseDialog,
   },
   setup() {
     const store = useAppStore();
@@ -417,7 +533,9 @@ export default {
     selectPreset(preset) {
       if (preset.data === undefined) {
         // load last workout
-        this.localData = JSON.parse(JSON.stringify(this.programStore.lastPreset));
+        this.localData = JSON.parse(
+          JSON.stringify(this.programStore.lastPreset)
+        );
         return;
       } else {
         this.localData.action.value = preset.data.action.value;
@@ -452,7 +570,7 @@ export default {
           );
           if (
             input.toLowerCase() ===
-            this.label_new_preset.trim().toLowerCase() ||
+              this.label_new_preset.trim().toLowerCase() ||
             preset_exists
           ) {
             return this.$q.notify({
@@ -552,7 +670,9 @@ export default {
       playSound("beepbeepbeep_1s", this.store.settings.audio_playback);
       await this.delay(1500);
 
-      this.programStore.setLastPreset(JSON.parse(JSON.stringify(this.localData)));
+      this.programStore.setLastPreset(
+        JSON.parse(JSON.stringify(this.localData))
+      );
 
       // start timer
       this.nextTimer();


### PR DESCRIPTION
## Summary
- add `BaseDialog` component for custom dialogs
- style card with `.white-shadow` utility
- simplify `ProgrammTimer` dialogs to use `BaseDialog`

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68763e2247548322b7e4fd64154aa221