### PR TITLE
Ensure consistent popup card shadow style

### DIFF
--- a/src/components/BaseDialog.vue
+++ b/src/components/BaseDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <q-dialog v-model="modelValue">
-    <q-card class="my-popup-card text-center white-shadow">
+    <q-card class="my-popup-card text-center">
       <q-card-section v-if="title">{{ title }}</q-card-section>
       <slot />
     </q-card>

--- a/src/components/ProgramSelectDialog.vue
+++ b/src/components/ProgramSelectDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <q-dialog v-model="modelValue">
-    <q-card class="my-popup-card text-center shadow-1">
+    <q-card class="my-popup-card text-center">
       <q-card-section>Programm auswählen</q-card-section>
       <q-card-section class="q-pa-none">
         <q-list style="max-height: 250px; overflow-y: auto">

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -63,9 +63,6 @@ body {
   max-width: 350px;
   background-color: $dark;
   color: $light;
-}
-
-.white-shadow {
   box-shadow: 0 0 8px white;
 }
 


### PR DESCRIPTION
## Summary
- add white box shadow to `.my-popup-card`
- update ProgramSelectDialog and BaseDialog to rely on `.my-popup-card`

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_687640036f288322b63a35294613dc7b