### PR TITLE
Add timer and program store tests

### DIFF
--- a/test/jest/__tests__/ProgramTimer.spec.js
+++ b/test/jest/__tests__/ProgramTimer.spec.js
@@ -14,6 +14,8 @@ jest.mock("src/tools/sound.js", () => ({
   default: jest.fn(),
 }));
 import ProgramTimer from "pages/Timer/ProgrammTimer.vue";
+import ProgramSelectDialog from "components/ProgramSelectDialog.vue";
+import BaseDialog from "components/BaseDialog.vue";
 import { useAppStore } from "stores/appStore";
 import { useProgramStore } from "stores/programStore";
 
@@ -30,10 +32,13 @@ describe("ProgramTimer", () => {
     setActivePinia(pinia);
     appStore = useAppStore();
     programStore = useProgramStore();
-    programStore.PROGRAM_STEPS = [{ type: "action", duration: 1, repetitions: 1 }];
+    programStore.PROGRAM_STEPS = [
+      { type: "action", duration: 1, repetitions: 1 },
+    ];
     wrapper = shallowMount(ProgramTimer, {
       global: {
         plugins: [pinia],
+        components: { ProgramSelectDialog, BaseDialog },
         mocks: { $router: { go: jest.fn() } },
         stubs: {
           "q-page": true,
@@ -42,7 +47,7 @@ describe("ProgramTimer", () => {
           "q-list": true,
           "q-item": true,
           "q-item-section": true,
-          "program-select-dialog": true,
+          "q-dialog": true,
           "q-popup-proxy": true,
           "q-card": true,
           "q-card-section": true,
@@ -111,6 +116,7 @@ describe("ProgramTimer", () => {
     const altWrapper = shallowMount(ProgramTimer, {
       global: {
         plugins: [pinia],
+        components: { ProgramSelectDialog, BaseDialog },
         mocks: { $router: { go: jest.fn() } },
         stubs: {
           "q-page": true,
@@ -119,7 +125,7 @@ describe("ProgramTimer", () => {
           "q-list": true,
           "q-item": true,
           "q-item-section": true,
-          "program-select-dialog": true,
+          "q-dialog": true,
           "q-popup-proxy": true,
           "q-card": true,
           "q-card-section": true,

--- a/test/jest/__tests__/programStore.spec.js
+++ b/test/jest/__tests__/programStore.spec.js
@@ -27,6 +27,50 @@ describe("programStore", () => {
       round_break: { value: 0 },
     };
     store.updatePreset("Tabata", data);
-    expect(store.presets.find((p) => p.label === "Tabata").data.action.value).toBe(10);
+    expect(
+      store.presets.find((p) => p.label === "Tabata").data.action.value
+    ).toBe(10);
+  });
+
+  it("addPreset stores preset and persists", () => {
+    const preset = {
+      label: "Test",
+      data: {
+        action: { value: 1 },
+        break: { value: 1 },
+        exercises: { value: 1 },
+        rounds: { value: 1 },
+        round_break: { value: 0 },
+      },
+    };
+    store.addPreset(preset);
+    expect(store.presets).toContainEqual(preset);
+    expect(JSON.parse(localStorage.getItem("presets"))).toContainEqual(preset);
+  });
+
+  it("removePreset deletes preset and updates storage", () => {
+    const preset = { label: "Custom", data: { action: { value: 1 } } };
+    store.addPreset(preset);
+    store.removePreset("Custom");
+    expect(store.presets.some((p) => p.label === "Custom")).toBe(false);
+    expect(
+      JSON.parse(localStorage.getItem("presets")).some(
+        (p) => p.label === "Custom"
+      )
+    ).toBe(false);
+  });
+
+  it("step management functions modify program steps", () => {
+    store.PROGRAM_STEPS = [
+      { type: "action", duration: 1, repetitions: 1 },
+      { type: "break", duration: 1, repetitions: 1 },
+      { type: "action", duration: 2, repetitions: 1 },
+    ];
+    store.removeProgramStep(1);
+    expect(store.programSteps.length).toBe(2);
+    store.moveProgramStep(1, 0);
+    expect(store.programSteps[0].duration).toBe(2);
+    store.updateProgramStep(0, { duration: 5 });
+    expect(store.programSteps[0].duration).toBe(5);
   });
 });

--- a/test/jest/__tests__/timerStore.spec.js
+++ b/test/jest/__tests__/timerStore.spec.js
@@ -1,0 +1,51 @@
+import {
+  beforeEach,
+  afterEach,
+  describe,
+  it,
+  expect,
+  jest,
+} from "@jest/globals";
+import { createPinia, setActivePinia } from "pinia";
+import { useTimerStore } from "stores/timerStore";
+
+describe("timerStore", () => {
+  let store;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setActivePinia(createPinia());
+    store = useTimerStore();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("starts timer and finishes after duration", () => {
+    store.start(2);
+    expect(store.running).toBe(true);
+    jest.advanceTimersByTime(1000);
+    expect(store.progress).toBe(1);
+    jest.advanceTimersByTime(1000);
+    expect(store.finished).toBe(true);
+    expect(store.running).toBe(false);
+  });
+
+  it("stop resets state by default", () => {
+    store.start(5);
+    jest.advanceTimersByTime(1000);
+    store.stop();
+    expect(store.running).toBe(false);
+    expect(store.progress).toBe(0);
+    expect(store.finished).toBe(false);
+  });
+
+  it("stop(false) keeps progress", () => {
+    store.start(3);
+    jest.advanceTimersByTime(1000);
+    store.stop(false);
+    expect(store.progress).toBe(1);
+    expect(store.finished).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for timerStore
- expand programStore tests for presets and step management
- mount ProgramSelectDialog and BaseDialog in ProgramTimer tests

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68764dcf0c988322bb090450f8dc5bc7