### PR TITLE
Remove legacy PNPM options from .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
 # pnpm-related options
-shamefully-hoist=true
-strict-peer-dependencies=false


### PR DESCRIPTION
## Summary
- clean `.npmrc` by deleting old pnpm options

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_687652f5bf0c8322bc45d917d763c1da