### PR TITLE
Update proxy note

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ npm install
 yarn
 ```
 
+> **Proxy configuration:** npm looks for `proxy` or `https-proxy` settings.
+> Configure your proxy via `NPM_CONFIG_PROXY` or add `proxy=<url>` in your
+> `.npmrc` instead of using `npm_config_http_proxy`.
+
 ### Development server
 Run the dev server with hot reloading:
 


### PR DESCRIPTION
## Summary
- mention `proxy`/`https-proxy` variables in npm install docs
- note about configuring `NPM_CONFIG_PROXY` or using `.npmrc`

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68765723a2ec832290c92e9702750f3b