### PR TITLE
Add ESM type flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "productName": "Quasar App",
   "author": "stebro <stefan.brodoehl@gmail.com>",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "quasar dev",
     "ios": "quasar dev -m ios --ide",


### PR DESCRIPTION
## Summary
- enable ES module mode by adding `"type": "module"` to `package.json`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6876586fc0c88322b3addc630326cbc9