### PR TITLE
Refactor timer settings

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -13,4 +13,7 @@ export default {
   transform: {
     '.*\\.js$': 'babel-jest',
   },
+  moduleNameMapper: {
+    '\\.(wav)$': '<rootDir>/test/jest/__mocks__/fileMock.js',
+  },
 };

--- a/src/components/ProgramBaseSettings.vue
+++ b/src/components/ProgramBaseSettings.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="row q-gutter-y-md" style="width: 100vw; max-width: 1000px">
+    <!-- Action -->
+    <div class="col-12">
+      <q-btn no-caps class="my-main-btn" @click="showActionDialog = true">
+        <q-icon name="play_circle" class="q-mr-sm" />Action:
+        {{ formatTime(localData.action.value) }}
+      </q-btn>
+      <BaseDialog v-model="showActionDialog" title="Action anpassen">
+        <q-card-section>
+          <DurationSlider v-model="localData.action.value" :min="5" :max="3600" :step="5" />
+        </q-card-section>
+      </BaseDialog>
+    </div>
+
+    <!-- Pause -->
+    <div class="col-12">
+      <q-btn no-caps class="my-main-btn" color="negative" @click="showBreakDialog = true">
+        <q-icon name="pause_circle" class="q-mr-sm" />Pause:
+        {{ formatTime(localData.break.value) }}
+      </q-btn>
+      <BaseDialog v-model="showBreakDialog" title="Pause anpassen">
+        <q-card-section>
+          <DurationSlider v-model="localData.break.value" :min="0" :max="3600" :step="5" />
+        </q-card-section>
+      </BaseDialog>
+    </div>
+
+    <!-- Excercises -->
+    <div class="col-12">
+      <q-btn no-caps class="my-main-btn" color="secondary" @click="showExerciseDialog = true">
+        <q-icon name="fitness_center" class="q-mr-sm" />Übungen:
+        {{ localData.exercises.value }} {{ localData.exercises.unit }}
+      </q-btn>
+      <BaseDialog v-model="showExerciseDialog" title="Übungen anpassen" size="500px">
+        <q-card-section>
+          <q-slider v-model="localData.exercises.value" label label-text-color="dark" color="white"
+            thumb-size="50px" :step="1" :min="1" :max="50" />
+        </q-card-section>
+        <q-card-section v-if="localData.exercises.value > 1">
+          <div class="q-gutter-sm">
+            <q-input v-for="n in localData.exercises.value" :key="'name' + n" dense type="text"
+              input-class="text-white" label-color="grey-8" :label="'Übung ' + n"
+              v-model="localData.exerciseNames[n - 1]" />
+          </div>
+        </q-card-section>
+      </BaseDialog>
+    </div>
+
+    <q-separator class="q-my-md" />
+
+    <!-- Repetitions -->
+    <div class="col-12">
+      <q-btn no-caps class="my-main-btn" color="secondary" @click="showRoundsDialog = true">
+        <q-icon name="restart_alt" class="q-mr-sm" />Wiederholungen:
+        {{ localData.rounds.value }} {{ localData.rounds.unit }}
+      </q-btn>
+      <BaseDialog v-model="showRoundsDialog" title="Wiederholungen anpassen">
+        <q-card-section>
+          <q-slider v-model="localData.rounds.value" label label-text-color="dark" color="white"
+            thumb-size="50px" :step="1" :min="1" :max="50" />
+        </q-card-section>
+      </BaseDialog>
+    </div>
+
+    <!-- BREAKS -->
+    <div class="col-12">
+      <q-btn no-caps class="my-main-btn" color="negative" @click="showRoundBreakDialog = true">
+        <q-icon name="restore" class="q-mr-sm" />Rundenpause:
+        {{ formatTime(localData.round_break.value) }}
+      </q-btn>
+      <BaseDialog v-model="showRoundBreakDialog" title="Rundenpause anpassen">
+        <q-card-section>
+          <DurationSlider v-model="localData.round_break.value" :min="0" :max="3600" :step="5" />
+        </q-card-section>
+      </BaseDialog>
+    </div>
+
+    <q-separator class="q-my-md" />
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import DurationSlider from 'components/DurationSlider.vue';
+import BaseDialog from 'components/BaseDialog.vue';
+import { formatTime } from 'src/utils/timeUtils';
+
+const props = defineProps({
+  localData: {
+    type: Object,
+    required: true,
+  },
+});
+
+const showActionDialog = ref(false);
+const showBreakDialog = ref(false);
+const showExerciseDialog = ref(false);
+const showRoundsDialog = ref(false);
+const showRoundBreakDialog = ref(false);
+</script>

--- a/src/pages/Timer/ProgrammTimer.vue
+++ b/src/pages/Timer/ProgrammTimer.vue
@@ -46,83 +46,7 @@
             </q-item>
           </div>
 
-          <!-- Action -->
-          <div class="col-12">
-            <q-btn no-caps class="my-main-btn" @click="showActionDialog = true">
-              <q-icon name="play_circle" class="q-mr-sm" />Action:
-              {{ formatTime(localData.action.value) }}
-            </q-btn>
-            <BaseDialog v-model="showActionDialog" title="Action anpassen">
-              <q-card-section>
-                <DurationSlider v-model="localData.action.value" :min="5" :max="3600" :step="5" />
-              </q-card-section>
-            </BaseDialog>
-          </div>
-
-          <!-- Pause -->
-          <div class="col-12">
-            <q-btn no-caps class="my-main-btn" color="negative" @click="showBreakDialog = true">
-              <q-icon name="pause_circle" class="q-mr-sm" />Pause:
-              {{ formatTime(localData.break.value) }}
-            </q-btn>
-            <BaseDialog v-model="showBreakDialog" title="Pause anpassen">
-              <q-card-section>
-                <DurationSlider v-model="localData.break.value" :min="0" :max="3600" :step="5" />
-              </q-card-section>
-            </BaseDialog>
-          </div>
-
-          <!-- Excercises -->
-          <div class="col-12">
-            <q-btn no-caps class="my-main-btn" color="secondary" @click="showExerciseDialog = true">
-              <q-icon name="fitness_center" class="q-mr-sm" />Übungen:
-              {{ localData.exercises.value }} {{ localData.exercises.unit }}
-            </q-btn>
-            <BaseDialog v-model="showExerciseDialog" title="Übungen anpassen" size="500px">
-              <q-card-section>
-                <q-slider v-model="localData.exercises.value" label label-text-color="dark" color="white"
-                  thumb-size="50px" :step="1" :min="1" :max="50" />
-              </q-card-section>
-              <q-card-section v-if="localData.exercises.value > 1">
-                <div class="q-gutter-sm">
-                  <q-input v-for="n in localData.exercises.value" :key="'name' + n" dense type="text"
-                    input-class="text-white" label-color="grey-8" :label="'Übung ' + n"
-                    v-model="localData.exerciseNames[n - 1]" />
-                </div>
-              </q-card-section>
-            </BaseDialog>
-          </div>
-
-          <q-separator class="q-my-md" />
-
-          <!-- Repetitions -->
-          <div class="col-12">
-            <q-btn no-caps class="my-main-btn" color="secondary" @click="showRoundsDialog = true">
-              <q-icon name="restart_alt" class="q-mr-sm" />Wiederholungen:
-              {{ localData.rounds.value }} {{ localData.rounds.unit }}
-            </q-btn>
-            <BaseDialog v-model="showRoundsDialog" title="Wiederholungen anpassen">
-              <q-card-section>
-                <q-slider v-model="localData.rounds.value" label label-text-color="dark" color="white" thumb-size="50px"
-                  :step="1" :min="1" :max="50" />
-              </q-card-section>
-            </BaseDialog>
-          </div>
-
-          <!-- BREAKS -->
-          <div class="col-12">
-            <q-btn no-caps class="my-main-btn" color="negative" @click="showRoundBreakDialog = true">
-              <q-icon name="restore" class="q-mr-sm" />Rundenpause:
-              {{ formatTime(localData.round_break.value) }}
-            </q-btn>
-            <BaseDialog v-model="showRoundBreakDialog" title="Rundenpause anpassen">
-              <q-card-section>
-                <DurationSlider v-model="localData.round_break.value" :min="0" :max="3600" :step="5" />
-              </q-card-section>
-            </BaseDialog>
-          </div>
-
-          <q-separator class="q-my-md" />
+          <ProgramBaseSettings :local-data="localData" />
         </div>
       </div>
 
@@ -186,9 +110,8 @@
 
 <script>
 import MY_ITEM_BTN from "components/MyItemBtn.vue";
-import DurationSlider from "components/DurationSlider.vue";
 import ProgramSelectDialog from "components/ProgramSelectDialog.vue";
-import BaseDialog from "components/BaseDialog.vue";
+import ProgramBaseSettings from "components/ProgramBaseSettings.vue";
 import getRandomCitation from "src/tools/citate.js";
 import { useAppStore } from "stores/appStore";
 import { useProgramStore } from "stores/programStore";
@@ -199,9 +122,8 @@ export default {
   name: "ProgrammTimer",
   components: {
     MY_ITEM_BTN,
-    DurationSlider,
     ProgramSelectDialog,
-    BaseDialog,
+    ProgramBaseSettings,
   },
   setup() {
     const store = useAppStore();
@@ -223,11 +145,6 @@ export default {
       label_new_preset: "Neues Programm",
       dragIndex: null,
       showPresetDialog: false,
-      showActionDialog: false,
-      showBreakDialog: false,
-      showExerciseDialog: false,
-      showRoundsDialog: false,
-      showRoundBreakDialog: false,
       stepDialogIndex: null,
       repDialogIndex: null,
     };

--- a/src/utils/timeUtils.js
+++ b/src/utils/timeUtils.js
@@ -9,7 +9,7 @@ export function formatTime(seconds) {
     date.setSeconds(seconds);
     return date.toISOString().substr(14, 5);
   }
-  return seconds.toString();
+  return `${seconds}s`;
 }
 
 /**

--- a/test/jest/__mocks__/fileMock.js
+++ b/test/jest/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+export default '';

--- a/test/jest/__tests__/ProgramTimer.spec.js
+++ b/test/jest/__tests__/ProgramTimer.spec.js
@@ -15,7 +15,6 @@ jest.mock("src/tools/sound.js", () => ({
 }));
 import ProgramTimer from "pages/Timer/ProgrammTimer.vue";
 import ProgramSelectDialog from "components/ProgramSelectDialog.vue";
-import BaseDialog from "components/BaseDialog.vue";
 import { useAppStore } from "stores/appStore";
 import { useProgramStore } from "stores/programStore";
 import { calcDuration } from "src/utils/timeUtils";
@@ -39,7 +38,7 @@ describe("ProgramTimer", () => {
     wrapper = shallowMount(ProgramTimer, {
       global: {
         plugins: [pinia],
-        components: { ProgramSelectDialog, BaseDialog },
+        components: { ProgramSelectDialog },
         mocks: { $router: { go: jest.fn() } },
         stubs: {
           "q-page": true,
@@ -118,7 +117,7 @@ describe("ProgramTimer", () => {
     const altWrapper = shallowMount(ProgramTimer, {
       global: {
         plugins: [pinia],
-        components: { ProgramSelectDialog, BaseDialog },
+        components: { ProgramSelectDialog },
         mocks: { $router: { go: jest.fn() } },
         stubs: {
           "q-page": true,


### PR DESCRIPTION
## Summary
- extract timer option controls to `ProgramBaseSettings` component
- adjust formatting of durations to append `s` for seconds
- register new component in `ProgrammTimer`
- update tests and Jest config for new component and add wav file mock

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68766cb57218832293acb1cf0fd3aea9