### PR TITLE
Document FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,38 @@
 # Sportsfreund Timer App
 
-A Quasar/Vue 3 timer application for organizing workouts. The app offers Quick Timer and Program Timer modes and lets you invite friends to share sessions.
+A Quasar/Vue 3 timer application for organizing workouts paired with a small FastAPI backend. The app offers Quick Timer and Program Timer modes and lets you invite friends to share sessions.
 
 ### Program Timer
 Workout steps are created automatically from your preset settings. Manual step addition is no longer available.
 
-## Project setup
+## Backend
+The Python backend uses **FastAPI** to handle user management and real-time chat.
+
+### Start the server
+Run the backend with a virtual environment:
+
+```bash
+python -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+uvicorn backend.server:app --reload
+```
+
+### Backend tests
+Execute the server tests with:
+
+```bash
+pytest
+```
+
+## Frontend
+The client is located in the `frontend` directory.
+
+### Project setup
 Install dependencies using npm or yarn:
 
 ```bash
+# from the repository root
+cd frontend
 npm install
 # or
 yarn
@@ -19,23 +43,23 @@ yarn
 > `.npmrc` instead of using `npm_config_http_proxy`.
 
 ### Development server
-Run the dev server with hot reloading:
+Run the dev server with hot reloading (first-time install shown for convenience):
 
 ```bash
-quasar dev
+cd frontend && npm install && quasar dev
 ```
 
 ### Build for production
 Create an optimized build:
 
 ```bash
-quasar build
+cd frontend && quasar build
 ```
 
 ### Unit tests
 Execute unit tests with:
 
 ```bash
-npm run test:unit
+cd frontend && npm run test:unit
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pytest
+httpx


### PR DESCRIPTION
## Summary
- update README with FastAPI backend instructions
- add requirements file for backend

## Testing
- `PYTHONPATH=. pytest -q`
- `cd frontend && npm run test:unit` *(fails: 1 failed, 9 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68769c85f52083228406870648a563ef