### PR TITLE
Add backend setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@ Workout steps are created automatically from your preset settings. Manual step a
 The Python backend uses **FastAPI** to handle user management and real-time chat.
 
 ### Start the server
-Run the backend with a virtual environment:
+Run the backend using the helper script. It sets up a virtual environment and
+installs dependencies from `backend/requirements.txt`.
 
 ```bash
-python -m venv venv && source venv/bin/activate
-pip install -r requirements.txt
-uvicorn backend.server:app --reload
+./start_backend.sh
 ```
 
 ### Backend tests

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/start_backend.sh
+++ b/start_backend.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+python -m venv venv
+source venv/bin/activate
+pip install -r backend/requirements.txt
+uvicorn backend.server:app --reload


### PR DESCRIPTION
## Summary
- add backend-specific requirements
- provide a shell script to start the backend
- document the helper script in the README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68769f5218b08322ab40c6b5fcc5344a