### PR TITLE
Refactor backend services

### DIFF
--- a/backend/services/friend_service.py
+++ b/backend/services/friend_service.py
@@ -1,0 +1,28 @@
+from fastapi import HTTPException
+
+from .user_service import load_users, save_users
+
+
+def send_request(uid: str, friend_uid: str) -> None:
+    """Add a friend request from ``uid`` to ``friend_uid``."""
+    users = load_users()
+    if friend_uid not in users:
+        raise HTTPException(status_code=404, detail="Friend not found")
+    target = users[friend_uid]
+    if uid not in target.get("requests", []):
+        target.setdefault("requests", []).append(uid)
+    save_users(users)
+
+
+def accept_request(uid: str, friend_uid: str) -> None:
+    """Accept a friend request for ``uid`` from ``friend_uid``."""
+    users = load_users()
+    user = users.get(uid)
+    friend = users.get(friend_uid)
+    if not user or not friend:
+        raise HTTPException(status_code=404, detail="User not found")
+    if friend_uid in user.get("requests", []):
+        user["requests"].remove(friend_uid)
+        user.setdefault("friends", []).append(friend_uid)
+        friend.setdefault("friends", []).append(uid)
+    save_users(users)

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -1,0 +1,43 @@
+import json
+import os
+from pathlib import Path
+
+
+def appdata_dir() -> Path:
+    """Return path to application data directory, creating it if needed."""
+    base = Path(os.getenv("APPDATA_PATH", Path(__file__).resolve().parent.parent / "appdata"))
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def users_file() -> Path:
+    return appdata_dir() / "user.json"
+
+
+def log_file() -> Path:
+    return appdata_dir() / "log.json"
+
+
+def _load_json(path: Path, default):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _save_json(path: Path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def load_users():
+    """Load user dictionary from disk."""
+    return _load_json(users_file(), {})
+
+
+def save_users(data):
+    """Persist user dictionary to disk."""
+    _save_json(users_file(), data)


### PR DESCRIPTION
## Summary
- add user_service and friend_service modules
- move JSON persistence and friend request logic into new services
- update FastAPI routes to use these services

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876aa414b9483229e68f4e97c202d4f