### PR TITLE
Add instructions for backend tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Execute the server tests with:
 pytest
 ```
 
+### Run backend tests
+Run the backend tests inside a virtual environment with:
+
+```bash
+source venv/bin/activate
+pip install -r backend/requirements.txt
+pytest backend/tests
+```
+
 ## Frontend
 The client is located in the `frontend` directory.
 


### PR DESCRIPTION
## Summary
- document how to run backend tests in a virtualenv

## Testing
- `venv/bin/python -m pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_6876abeea9a483229b17c4274464f8be