### PR TITLE
Fix backend tests by installing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.egg-info/
+.eggs/
+venv/
+.env
+
+# Logs
+*.log
+backend/appdata/*.txt
+
+# Node
+node_modules/
+frontend/node_modules/
+
+# Builds
+build/
+dist/
+frontend/dist/
+
+# IDE files
+.DS_Store
+.idea/
+.vscode/
+.pytest_cache/

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+httpx


### PR DESCRIPTION
## Summary
- add a repo `.gitignore` so generated files and venvs aren't tracked
- include `httpx` in backend requirements to satisfy `TestClient`
- run backend tests to ensure they pass

## Testing
- `PYTHONPATH=. pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6876cc1e72b483229554a9547fc3fe65