### PR TITLE
Add API error handling and tests

### DIFF
--- a/frontend/src/boot/axios.js
+++ b/frontend/src/boot/axios.js
@@ -1,5 +1,6 @@
-import { boot } from 'quasar/wrappers'
-import axios from 'axios'
+import { boot } from "quasar/wrappers";
+import axios from "axios";
+import { useErrorStore } from "stores/errorStore";
 
 // Be careful when using SSR for cross-request state pollution
 // due to creating a Singleton instance here;
@@ -7,18 +8,30 @@ import axios from 'axios'
 // good idea to move this instance creation inside of the
 // "export default () => {}" function below (which runs individually
 // for each client)
-const api = axios.create({ baseURL: 'http://localhost:8000' })
+const api = axios.create({ baseURL: "http://localhost:8000" });
 
 export default boot(({ app }) => {
   // for use inside Vue files (Options API) through this.$axios and this.$api
 
-  app.config.globalProperties.$axios = axios
+  app.config.globalProperties.$axios = axios;
   // ^ ^ ^ this will allow you to use this.$axios (for Vue Options API form)
   //       so you won't necessarily have to import axios in each vue file
 
-  app.config.globalProperties.$api = api
+  app.config.globalProperties.$api = api;
   // ^ ^ ^ this will allow you to use this.$api (for Vue Options API form)
   //       so you can easily perform requests against your app's API
-})
 
-export { api }
+  const errorStore = useErrorStore();
+  api.interceptors.response.use(
+    (response) => {
+      errorStore.setOk();
+      return response;
+    },
+    (error) => {
+      errorStore.setError(error.message);
+      return Promise.reject(error);
+    }
+  );
+});
+
+export { api };

--- a/frontend/src/boot/axios.js
+++ b/frontend/src/boot/axios.js
@@ -1,37 +1,11 @@
 import { boot } from "quasar/wrappers";
-import axios from "axios";
-import { useErrorStore } from "stores/errorStore";
-
-// Be careful when using SSR for cross-request state pollution
-// due to creating a Singleton instance here;
-// If any client changes this (global) instance, it might be a
-// good idea to move this instance creation inside of the
-// "export default () => {}" function below (which runs individually
-// for each client)
-const api = axios.create({ baseURL: "http://localhost:8000" });
-
+import { useApiStore } from "stores/apiStore";
 export default boot(({ app }) => {
-  // for use inside Vue files (Options API) through this.$axios and this.$api
+  const apiStore = useApiStore();
+  apiStore.init();
 
-  app.config.globalProperties.$axios = axios;
-  // ^ ^ ^ this will allow you to use this.$axios (for Vue Options API form)
-  //       so you won't necessarily have to import axios in each vue file
-
-  app.config.globalProperties.$api = api;
-  // ^ ^ ^ this will allow you to use this.$api (for Vue Options API form)
-  //       so you can easily perform requests against your app's API
-
-  const errorStore = useErrorStore();
-  api.interceptors.response.use(
-    (response) => {
-      errorStore.setOk();
-      return response;
-    },
-    (error) => {
-      errorStore.setError(error.message);
-      return Promise.reject(error);
-    }
-  );
+  app.config.globalProperties.$axios = apiStore.api;
+  app.config.globalProperties.$api = apiStore.api;
 });
 
-export { api };
+export { useApiStore };

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -1,9 +1,13 @@
 <template>
   <q-layout view="lHh Lpr lFf">
-    <q-header elevated class="bg-primary ">
+    <q-header elevated class="bg-primary">
       <q-toolbar>
-        <q-icon class="cursor-pointer" name="img:icons/favicon-96x96.png" size="sm"
-          @click="leftDrawerOpen = !leftDrawerOpen" />
+        <q-icon
+          class="cursor-pointer"
+          name="img:icons/favicon-96x96.png"
+          size="sm"
+          @click="leftDrawerOpen = !leftDrawerOpen"
+        />
         <q-toolbar-title class="text-center no-pointer-events">
           {{ store.env.APP_NAME }}
         </q-toolbar-title>
@@ -18,47 +22,62 @@
           Essential Links
         </q-item-label>
 
-        <EssentialLink v-for="link in essentialLinks" :key="link.title" :el="link" />
+        <EssentialLink
+          v-for="link in essentialLinks"
+          :key="link.title"
+          :el="link"
+        />
       </q-list>
       <div class="text-center q-pa-lg">
-        <q-img class="cursor-pointer" src="icons/favicon-128x128.png" width="100px"
-          @click="$router.push({ name: 'About' })" />
+        <q-img
+          class="cursor-pointer"
+          src="icons/favicon-128x128.png"
+          width="100px"
+          @click="$router.push({ name: 'About' })"
+        />
       </div>
     </q-drawer>
 
     <q-page-container>
-
       <router-view />
+      <q-page-sticky position="bottom-right" :offset="[18, 18]">
+        <q-icon name="circle" :color="apiColor" size="12px" />
+      </q-page-sticky>
     </q-page-container>
   </q-layout>
 </template>
 
-
 <script>
-import EssentialLink from 'components/EssentialLink.vue'
-import { useAppStore } from 'stores/appStore'
+import EssentialLink from "components/EssentialLink.vue";
+import { useAppStore } from "stores/appStore";
+import { useErrorStore } from "stores/errorStore";
 
 export default {
-  name: 'MainLayout',
+  name: "MainLayout",
   components: {
-    EssentialLink
+    EssentialLink,
   },
-  setup () {
-    const store = useAppStore()
-    return { store }
+  setup() {
+    const store = useAppStore();
+    const errorStore = useErrorStore();
+    return { store, errorStore };
   },
   mounted() {
-    this.store.log('MainLayout.vue::mounted()')
+    this.store.log("MainLayout.vue::mounted()");
   },
   data() {
     return {
       toggleLeftDrawer: false,
       leftDrawerOpen: false,
-      essentialLinks: this.store.getEssentialLinks
-    }
+      essentialLinks: this.store.getEssentialLinks,
+    };
   },
   computed: {
-
-  }
-}
+    apiColor() {
+      if (this.errorStore.apiStatus === "ok") return "green";
+      if (this.errorStore.apiStatus === "error") return "red";
+      return "grey";
+    },
+  },
+};
 </script>

--- a/frontend/src/stores/apiStore.js
+++ b/frontend/src/stores/apiStore.js
@@ -1,0 +1,38 @@
+import { defineStore } from "pinia";
+import axios from "axios";
+import { useErrorStore } from "stores/errorStore";
+
+export const useApiStore = defineStore("api", {
+  state: () => ({
+    api: null,
+  }),
+  actions: {
+    init() {
+      if (this.api) return;
+      this.api = axios.create({ baseURL: "http://localhost:8000" });
+      const errorStore = useErrorStore();
+      this.api.interceptors.response.use(
+        (response) => {
+          errorStore.setOk();
+          return response;
+        },
+        (error) => {
+          errorStore.setError(error.message);
+          return Promise.reject(error);
+        }
+      );
+    },
+    get(url, config) {
+      return this.api.get(url, config);
+    },
+    post(url, data, config) {
+      return this.api.post(url, data, config);
+    },
+    put(url, data, config) {
+      return this.api.put(url, data, config);
+    },
+    delete(url, config) {
+      return this.api.delete(url, config);
+    },
+  },
+});

--- a/frontend/src/stores/appStore.js
+++ b/frontend/src/stores/appStore.js
@@ -26,6 +26,8 @@ export const useAppStore = defineStore("app", {
           icon: "info",
           route: "ChangeLog",
         },
+        { titel: "Login", caption: "login", icon: "login", route: "Login" },
+        { titel: "Chat", caption: "chat", icon: "chat", route: "Chat" },
         { titel: "Impressum", caption: "", icon: "gavel", route: "Impressum" },
       ],
     };

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { api } from "boot/axios";
+import { useApiStore } from "stores/apiStore";
 
 export const useAuthStore = defineStore("auth", {
   state: () => ({
@@ -8,12 +8,14 @@ export const useAuthStore = defineStore("auth", {
   }),
   actions: {
     async register(username, password) {
+      const api = useApiStore();
       const res = await api.post("/register", { username, password });
       this.uid = res.data.uid;
       this.username = username;
       localStorage.setItem("uid", this.uid);
     },
     async login(username, password) {
+      const api = useApiStore();
       const res = await api.post("/login", { username, password });
       this.uid = res.data.uid;
       this.username = username;
@@ -24,9 +26,11 @@ export const useAuthStore = defineStore("auth", {
       if (id) this.uid = id;
     },
     async sendFriendRequest(friend_uid) {
+      const api = useApiStore();
       await api.post("/friend/request", { uid: this.uid, friend_uid });
     },
     async acceptFriend(friend_uid) {
+      const api = useApiStore();
       await api.post("/friend/accept", { uid: this.uid, friend_uid });
     },
   },

--- a/frontend/src/stores/errorStore.js
+++ b/frontend/src/stores/errorStore.js
@@ -1,0 +1,18 @@
+import { defineStore } from "pinia";
+
+export const useErrorStore = defineStore("error", {
+  state: () => ({
+    apiStatus: "unknown",
+    lastError: null,
+  }),
+  actions: {
+    setOk() {
+      this.apiStatus = "ok";
+      this.lastError = null;
+    },
+    setError(message) {
+      this.apiStatus = "error";
+      this.lastError = message;
+    },
+  },
+});

--- a/frontend/test/jest/__tests__/ChatPage.spec.js
+++ b/frontend/test/jest/__tests__/ChatPage.spec.js
@@ -1,0 +1,52 @@
+import { beforeEach, describe, it, expect, jest } from "@jest/globals";
+import { installQuasarPlugin } from "@quasar/quasar-app-extension-testing-unit-jest";
+import { shallowMount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import ChatPage from "pages/ChatPage.vue";
+import { useAuthStore } from "stores/authStore";
+
+installQuasarPlugin();
+
+describe("ChatPage", () => {
+  let store;
+  let wrapper;
+  let wsMock;
+
+  beforeEach(() => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    store = useAuthStore();
+    store.sendFriendRequest = jest.fn();
+    store.acceptFriend = jest.fn();
+    store.uid = "me";
+    wsMock = { send: jest.fn() };
+    global.WebSocket = jest.fn(() => wsMock);
+    wrapper = shallowMount(ChatPage, {
+      global: {
+        plugins: [pinia],
+        stubs: { "q-page": true, "q-input": true, "q-btn": true },
+      },
+    });
+  });
+
+  it("connect opens websocket and updates state", async () => {
+    wrapper.vm.friend = "you";
+    await wrapper.vm.connect();
+    expect(global.WebSocket).toHaveBeenCalledWith("ws://localhost:8000/ws/me");
+    wsMock.onopen();
+    expect(wrapper.vm.connected).toBe(true);
+    wsMock.onmessage({ data: JSON.stringify({ from: "you", message: "hi" }) });
+    expect(wrapper.vm.messages[0].text).toBe("hi");
+  });
+
+  it("send forwards message over websocket", async () => {
+    wrapper.vm.friend = "you";
+    await wrapper.vm.connect();
+    wrapper.vm.text = "hello";
+    wrapper.vm.send();
+    expect(wsMock.send).toHaveBeenCalledWith(
+      JSON.stringify({ to: "you", message: "hello" })
+    );
+    expect(wrapper.vm.text).toBe("");
+  });
+});

--- a/frontend/test/jest/__tests__/LoginPage.spec.js
+++ b/frontend/test/jest/__tests__/LoginPage.spec.js
@@ -1,0 +1,41 @@
+import { beforeEach, describe, it, expect, jest } from "@jest/globals";
+import { installQuasarPlugin } from "@quasar/quasar-app-extension-testing-unit-jest";
+import { shallowMount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import LoginPage from "pages/LoginPage.vue";
+import { useAuthStore } from "stores/authStore";
+
+installQuasarPlugin();
+
+describe("LoginPage", () => {
+  let store;
+  let wrapper;
+
+  beforeEach(() => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    store = useAuthStore();
+    store.login = jest.fn();
+    store.register = jest.fn();
+    wrapper = shallowMount(LoginPage, {
+      global: {
+        plugins: [pinia],
+        stubs: { "q-page": true, "q-input": true, "q-btn": true },
+      },
+    });
+  });
+
+  it("calls login on doLogin", async () => {
+    wrapper.vm.username = "u";
+    wrapper.vm.password = "p";
+    await wrapper.vm.doLogin();
+    expect(store.login).toHaveBeenCalledWith("u", "p");
+  });
+
+  it("calls register on doRegister", async () => {
+    wrapper.vm.username = "u";
+    wrapper.vm.password = "p";
+    await wrapper.vm.doRegister();
+    expect(store.register).toHaveBeenCalledWith("u", "p");
+  });
+});

--- a/frontend/test/jest/__tests__/authStore.spec.js
+++ b/frontend/test/jest/__tests__/authStore.spec.js
@@ -2,11 +2,11 @@ import { beforeEach, describe, it, expect, jest } from "@jest/globals";
 import { createPinia, setActivePinia } from "pinia";
 import { useAuthStore } from "stores/authStore";
 
-jest.mock("boot/axios", () => ({
-  api: { post: jest.fn(() => Promise.resolve({ data: { uid: "123" } })) }
-}))
-import { api } from "boot/axios"
-const postMock = api.post
+jest.mock("stores/apiStore", () => {
+  const postMock = jest.fn(() => Promise.resolve({ data: { uid: "123" } }));
+  return { useApiStore: () => ({ post: postMock }), postMock };
+});
+import { postMock } from "stores/apiStore";
 
 describe("authStore", () => {
   let store;


### PR DESCRIPTION
## Summary
- add Login and Chat links to navigation
- provide error store to track API status
- show API status indicator in main layout
- handle axios errors globally
- add component tests for login and chat

## Testing
- `npm run lint`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6876d229878c8322a8d1255cf31a5593