### PR TITLE
Fix CORS and add register page

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -4,10 +4,20 @@ import os
 import uuid
 from pathlib import Path
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi.middleware.cors import CORSMiddleware
 
 from .services import friend_service, user_service
 
 app = FastAPI()
+
+# Enable CORS for frontend requests
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 def _log_dir() -> Path:

--- a/backend/tests/test_server.py
+++ b/backend/tests/test_server.py
@@ -56,3 +56,16 @@ def test_log_endpoint(tmp_path):
     assert log_file.exists()
     contents = log_file.read_text()
     assert msg in contents
+
+
+def test_cors_options(tmp_path):
+    client = setup_env(tmp_path)
+    r = client.options(
+        "/login",
+        headers={
+            "Origin": "http://localhost:8080",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers.get("access-control-allow-origin") == "http://localhost:8080"

--- a/frontend/src/pages/RegisterPage.vue
+++ b/frontend/src/pages/RegisterPage.vue
@@ -1,0 +1,27 @@
+<template>
+  <q-page class="row items-center justify-center">
+    <div class="column q-gutter-sm" style="width: 300px">
+      <q-input v-model="username" label="Username" />
+      <q-input v-model="password" type="password" label="Password" />
+      <q-btn label="Register" color="primary" @click="doRegister" />
+      <q-btn
+        label="Back to Login"
+        flat
+        @click="$router.push({ name: 'Login' })"
+      />
+    </div>
+  </q-page>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import { useAuthStore } from "stores/authStore";
+
+const store = useAuthStore();
+const username = ref("");
+const password = ref("");
+
+const doRegister = async () => {
+  await store.register(username.value, password.value);
+};
+</script>

--- a/frontend/src/router/routes.js
+++ b/frontend/src/router/routes.js
@@ -1,37 +1,76 @@
-
 const routes = [
   {
-    path: '/',
-    component: () => import('layouts/MainLayout.vue'),
+    path: "/",
+    component: () => import("layouts/MainLayout.vue"),
     children: [
-      { path: '', name: 'Index', component: () => import('pages/IndexPage.vue') },
-      { path: 'about', name: 'About', component: () => import('pages/AboutPage.vue') },
-      { path: 'changelog', name: 'ChangeLog', component: () => import('pages/ChangeLogPage.vue') },
-      { path: 'impressum', name: 'Impressum', component: () => import('pages/ImpressumPage.vue') },
-      { path: 'login', name: 'Login', component: () => import('pages/LoginPage.vue') },
-      { path: 'chat', name: 'Chat', component: () => import('pages/ChatPage.vue') },
-
-    ]
+      {
+        path: "",
+        name: "Index",
+        component: () => import("pages/IndexPage.vue"),
+      },
+      {
+        path: "about",
+        name: "About",
+        component: () => import("pages/AboutPage.vue"),
+      },
+      {
+        path: "changelog",
+        name: "ChangeLog",
+        component: () => import("pages/ChangeLogPage.vue"),
+      },
+      {
+        path: "impressum",
+        name: "Impressum",
+        component: () => import("pages/ImpressumPage.vue"),
+      },
+      {
+        path: "login",
+        name: "Login",
+        component: () => import("pages/LoginPage.vue"),
+      },
+      {
+        path: "register",
+        name: "Register",
+        component: () => import("pages/RegisterPage.vue"),
+      },
+      {
+        path: "chat",
+        name: "Chat",
+        component: () => import("pages/ChatPage.vue"),
+      },
+    ],
   },
 
   // Timer
   {
-    path: '/timer',
-    name: 'Timer',
-    component: () => import('src/layouts/TimerLayout.vue'),
+    path: "/timer",
+    name: "Timer",
+    component: () => import("src/layouts/TimerLayout.vue"),
     children: [
-      { path: 'timer', name: 'QuickTimer', components: { 'timer': () => import('pages/Timer/QuickTimer.vue') } },
-      { path: 'program', name: 'ProgramTimer', components: { 'timer': () => import('pages/Timer/ProgrammTimer.vue') } },
-      { path: 'friends', name: 'InviteFriends', components: { 'timer': () => import('pages/Timer/InviteFriends.vue') } }
-    ]
+      {
+        path: "timer",
+        name: "QuickTimer",
+        components: { timer: () => import("pages/Timer/QuickTimer.vue") },
+      },
+      {
+        path: "program",
+        name: "ProgramTimer",
+        components: { timer: () => import("pages/Timer/ProgrammTimer.vue") },
+      },
+      {
+        path: "friends",
+        name: "InviteFriends",
+        components: { timer: () => import("pages/Timer/InviteFriends.vue") },
+      },
+    ],
   },
 
   // Always leave this as last one,
   // but you can also remove it
   {
-    path: '/:catchAll(.*)*',
-    component: () => import('pages/ErrorNotFound.vue')
-  }
-]
+    path: "/:catchAll(.*)*",
+    component: () => import("pages/ErrorNotFound.vue"),
+  },
+];
 
-export default routes
+export default routes;

--- a/frontend/src/stores/appStore.js
+++ b/frontend/src/stores/appStore.js
@@ -27,6 +27,12 @@ export const useAppStore = defineStore("app", {
           route: "ChangeLog",
         },
         { titel: "Login", caption: "login", icon: "login", route: "Login" },
+        {
+          titel: "Register",
+          caption: "register",
+          icon: "person_add",
+          route: "Register",
+        },
         { titel: "Chat", caption: "chat", icon: "chat", route: "Chat" },
         { titel: "Impressum", caption: "", icon: "gavel", route: "Impressum" },
       ],

--- a/frontend/test/jest/__tests__/RegisterPage.spec.js
+++ b/frontend/test/jest/__tests__/RegisterPage.spec.js
@@ -1,0 +1,33 @@
+import { beforeEach, describe, it, expect, jest } from "@jest/globals";
+import { installQuasarPlugin } from "@quasar/quasar-app-extension-testing-unit-jest";
+import { shallowMount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import RegisterPage from "pages/RegisterPage.vue";
+import { useAuthStore } from "stores/authStore";
+
+installQuasarPlugin();
+
+describe("RegisterPage", () => {
+  let store;
+  let wrapper;
+
+  beforeEach(() => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    store = useAuthStore();
+    store.register = jest.fn();
+    wrapper = shallowMount(RegisterPage, {
+      global: {
+        plugins: [pinia],
+        stubs: { "q-page": true, "q-input": true, "q-btn": true },
+      },
+    });
+  });
+
+  it("calls register on doRegister", async () => {
+    wrapper.vm.username = "u";
+    wrapper.vm.password = "p";
+    await wrapper.vm.doRegister();
+    expect(store.register).toHaveBeenCalledWith("u", "p");
+  });
+});


### PR DESCRIPTION
## Summary
- enable CORS in FastAPI backend
- test CORS preflight handling
- add dedicated Register page and route
- expose registration link in navigation
- test the new Register page

## Testing
- `npx prettier --write src/pages/RegisterPage.vue src/router/routes.js src/stores/appStore.js test/jest/__tests__/RegisterPage.spec.js`
- `npx eslint src/pages/RegisterPage.vue src/router/routes.js src/stores/appStore.js test/jest/__tests__/RegisterPage.spec.js`
- `npm run test:unit`
- `PYTHONPATH=. pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68774ce1bafc8322b93eb6333a21fb53