### PR TITLE
Add confirmation to registration

### DIFF
--- a/frontend/src/pages/RegisterPage.vue
+++ b/frontend/src/pages/RegisterPage.vue
@@ -3,6 +3,11 @@
     <div class="column q-gutter-sm" style="width: 300px">
       <q-input v-model="username" label="Username" />
       <q-input v-model="password" type="password" label="Password" />
+      <q-input
+        v-model="passwordConfirm"
+        type="password"
+        label="Confirm Password"
+      />
       <q-btn label="Register" color="primary" @click="doRegister" />
       <q-btn
         label="Back to Login"
@@ -15,13 +20,29 @@
 
 <script setup>
 import { ref } from "vue";
+import { useRouter } from "vue-router";
+import { useQuasar } from "quasar";
 import { useAuthStore } from "stores/authStore";
 
 const store = useAuthStore();
 const username = ref("");
 const password = ref("");
+const passwordConfirm = ref("");
+const $q = useQuasar();
+const router = useRouter();
 
 const doRegister = async () => {
-  await store.register(username.value, password.value);
+  if (password.value !== passwordConfirm.value) {
+    $q.notify({ type: "negative", message: "Passwords do not match" });
+    return;
+  }
+  try {
+    await store.register(username.value, password.value);
+    $q.notify({ type: "positive", message: "Registration successful" });
+    router.push({ name: "Login" });
+  } catch (err) {
+    const msg = err.response?.data?.detail || err.message;
+    $q.notify({ type: "negative", message: msg });
+  }
 };
 </script>

--- a/frontend/test/jest/__tests__/RegisterPage.spec.js
+++ b/frontend/test/jest/__tests__/RegisterPage.spec.js
@@ -4,30 +4,56 @@ import { shallowMount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import RegisterPage from "pages/RegisterPage.vue";
 import { useAuthStore } from "stores/authStore";
+import { createRouter, createMemoryHistory } from "vue-router";
 
 installQuasarPlugin();
 
 describe("RegisterPage", () => {
   let store;
   let wrapper;
+  let routerPush;
+  let notifyMock;
 
   beforeEach(() => {
     const pinia = createPinia();
     setActivePinia(pinia);
     store = useAuthStore();
-    store.register = jest.fn();
+    store.register = jest.fn().mockResolvedValue();
+    routerPush = jest.fn();
+    const router = createRouter({ history: createMemoryHistory(), routes: [] });
+    router.push = routerPush;
     wrapper = shallowMount(RegisterPage, {
       global: {
-        plugins: [pinia],
+        plugins: [pinia, router],
         stubs: { "q-page": true, "q-input": true, "q-btn": true },
       },
     });
+    notifyMock = jest.fn();
+    wrapper.vm.$q.notify = notifyMock;
   });
 
   it("calls register on doRegister", async () => {
     wrapper.vm.username = "u";
     wrapper.vm.password = "p";
+    wrapper.vm.passwordConfirm = "p";
     await wrapper.vm.doRegister();
     expect(store.register).toHaveBeenCalledWith("u", "p");
+  });
+
+  it("prevents registration when passwords mismatch", async () => {
+    wrapper.vm.username = "u";
+    wrapper.vm.password = "a";
+    wrapper.vm.passwordConfirm = "b";
+    await wrapper.vm.doRegister();
+    expect(store.register).not.toHaveBeenCalled();
+    expect(notifyMock).toHaveBeenCalled();
+  });
+
+  it("navigates to Login on success", async () => {
+    wrapper.vm.username = "u";
+    wrapper.vm.password = "p";
+    wrapper.vm.passwordConfirm = "p";
+    await wrapper.vm.doRegister();
+    expect(routerPush).toHaveBeenCalledWith({ name: "Login" });
   });
 });


### PR DESCRIPTION
## Summary
- validate password confirmation on the register page
- show notifications and navigate after registration
- test mismatched passwords and navigation

## Testing
- `npx eslint src/pages/RegisterPage.vue test/jest/__tests__/RegisterPage.spec.js`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_687754791d6c8322ad7a6f9f93f3bab8