### PR TITLE
Improve login error handling

### DIFF
--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -11,14 +11,22 @@
 
 <script setup>
 import { ref } from "vue";
+import { useQuasar } from "quasar";
 import { useAuthStore } from "stores/authStore";
 
 const store = useAuthStore();
 const username = ref("");
 const password = ref("");
+const $q = useQuasar();
 
 const doLogin = async () => {
-  await store.login(username.value, password.value);
+  try {
+    await store.login(username.value, password.value);
+    $q.notify({ type: "positive", message: "Login successful" });
+  } catch (err) {
+    const msg = err.response?.data?.detail || err.message;
+    $q.notify({ type: "negative", message: msg });
+  }
 };
 
 const doRegister = async () => {

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -9,17 +9,25 @@ export const useAuthStore = defineStore("auth", {
   actions: {
     async register(username, password) {
       const api = useApiStore();
-      const res = await api.post("/register", { username, password });
-      this.uid = res.data.uid;
-      this.username = username;
-      localStorage.setItem("uid", this.uid);
+      try {
+        const res = await api.post("/register", { username, password });
+        this.uid = res.data.uid;
+        this.username = username;
+        localStorage.setItem("uid", this.uid);
+      } catch (err) {
+        throw err;
+      }
     },
     async login(username, password) {
       const api = useApiStore();
-      const res = await api.post("/login", { username, password });
-      this.uid = res.data.uid;
-      this.username = username;
-      localStorage.setItem("uid", this.uid);
+      try {
+        const res = await api.post("/login", { username, password });
+        this.uid = res.data.uid;
+        this.username = username;
+        localStorage.setItem("uid", this.uid);
+      } catch (err) {
+        throw err;
+      }
     },
     autoLogin() {
       const id = localStorage.getItem("uid");

--- a/frontend/test/jest/__tests__/LoginPage.spec.js
+++ b/frontend/test/jest/__tests__/LoginPage.spec.js
@@ -10,12 +10,13 @@ installQuasarPlugin();
 describe("LoginPage", () => {
   let store;
   let wrapper;
+  let notifyMock;
 
   beforeEach(() => {
     const pinia = createPinia();
     setActivePinia(pinia);
     store = useAuthStore();
-    store.login = jest.fn();
+    store.login = jest.fn().mockResolvedValue();
     store.register = jest.fn();
     wrapper = shallowMount(LoginPage, {
       global: {
@@ -23,13 +24,30 @@ describe("LoginPage", () => {
         stubs: { "q-page": true, "q-input": true, "q-btn": true },
       },
     });
+    notifyMock = jest.fn();
+    wrapper.vm.$q.notify = notifyMock;
   });
 
-  it("calls login on doLogin", async () => {
+  it("shows success notify on login", async () => {
     wrapper.vm.username = "u";
     wrapper.vm.password = "p";
     await wrapper.vm.doLogin();
     expect(store.login).toHaveBeenCalledWith("u", "p");
+    expect(notifyMock).toHaveBeenCalledWith({
+      type: "positive",
+      message: "Login successful",
+    });
+  });
+
+  it("shows error notify on failed login", async () => {
+    store.login.mockRejectedValue(new Error("bad"));
+    wrapper.vm.username = "u";
+    wrapper.vm.password = "p";
+    await wrapper.vm.doLogin();
+    expect(notifyMock).toHaveBeenCalledWith({
+      type: "negative",
+      message: "bad",
+    });
   });
 
   it("calls register on doRegister", async () => {


### PR DESCRIPTION
## Summary
- rethrow auth errors from `register` and `login`
- notify users about login success or errors
- test login notifications

## Testing
- `npx prettier -w src/stores/authStore.js src/pages/LoginPage.vue test/jest/__tests__/LoginPage.spec.js`
- `npx eslint src/stores/authStore.js src/pages/LoginPage.vue test/jest/__tests__/LoginPage.spec.js`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68775796d6b88322aad20e08e4049269