### PR TITLE
Add UID copy feature

### DIFF
--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -13,6 +13,16 @@
         </q-toolbar-title>
 
         <div class="no-pointer-events">{{ store.env.APP_VERSION }}</div>
+        <q-space />
+        <div v-if="auth.uid" class="row items-center">
+          <span class="q-mr-xs">{{ auth.username }} ({{ auth.uid }})</span>
+          <q-icon
+            name="content_copy"
+            class="cursor-pointer"
+            data-testid="copy-btn"
+            @click="copyUid"
+          />
+        </div>
       </q-toolbar>
     </q-header>
 
@@ -51,6 +61,7 @@
 import EssentialLink from "components/EssentialLink.vue";
 import { useAppStore } from "stores/appStore";
 import { useErrorStore } from "stores/errorStore";
+import { useAuthStore } from "stores/authStore";
 
 export default {
   name: "MainLayout",
@@ -60,7 +71,8 @@ export default {
   setup() {
     const store = useAppStore();
     const errorStore = useErrorStore();
-    return { store, errorStore };
+    const auth = useAuthStore();
+    return { store, errorStore, auth };
   },
   mounted() {
     this.store.log("MainLayout.vue::mounted()");
@@ -77,6 +89,13 @@ export default {
       if (this.errorStore.apiStatus === "ok") return "green";
       if (this.errorStore.apiStatus === "error") return "red";
       return "grey";
+    },
+  },
+  methods: {
+    copyUid() {
+      if (this.auth.uid) {
+        navigator.clipboard.writeText(this.auth.uid);
+      }
     },
   },
 };

--- a/frontend/test/jest/__tests__/MainLayout.spec.js
+++ b/frontend/test/jest/__tests__/MainLayout.spec.js
@@ -1,0 +1,36 @@
+import { beforeEach, describe, it, expect, jest } from "@jest/globals";
+import { installQuasarPlugin } from "@quasar/quasar-app-extension-testing-unit-jest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import MainLayout from "layouts/MainLayout.vue";
+import { useAuthStore } from "stores/authStore";
+
+installQuasarPlugin();
+
+describe("MainLayout", () => {
+  let wrapper;
+  let store;
+
+  beforeEach(() => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    store = useAuthStore();
+    store.uid = "abc";
+    wrapper = mount(MainLayout, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          EssentialLink: true,
+          "router-view": true,
+        },
+      },
+    });
+    global.navigator.clipboard = { writeText: jest.fn() };
+  });
+
+  it("copies uid to clipboard", async () => {
+    const copy = wrapper.find('[data-testid="copy-btn"]');
+    await copy.trigger("click");
+    expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith("abc");
+  });
+});


### PR DESCRIPTION
## Summary
- show authenticated username and UID in `MainLayout`
- allow copying UID via clipboard button
- test clipboard behaviour

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68775a82db7c8322aee892108af58a86