### PR TITLE
Add user update/delete API and page

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -111,6 +111,26 @@ def login(payload: dict):
     raise HTTPException(status_code=401, detail='Invalid credentials')
 
 
+@app.put('/user/{uid}')
+def update_user(uid: str, payload: dict):
+    """Modify an existing user."""
+    values = {}
+    for key in ('username', 'password', 'age'):
+        if key in payload:
+            values[key] = payload[key]
+    user_service.update_user(uid, values)
+    log_event({'event': 'update_user', 'uid': uid})
+    return {'status': 'updated'}
+
+
+@app.delete('/user/{uid}')
+def remove_user(uid: str):
+    """Delete a user account."""
+    user_service.delete_user(uid)
+    log_event({'event': 'delete_user', 'uid': uid})
+    return {'status': 'deleted'}
+
+
 @app.post('/friend/request')
 def friend_request(payload: dict):
     uid = payload['uid']

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+from fastapi import HTTPException
 
 
 def appdata_dir() -> Path:
@@ -41,3 +42,23 @@ def load_users():
 def save_users(data):
     """Persist user dictionary to disk."""
     _save_json(users_file(), data)
+
+
+def update_user(uid: str, values: dict) -> None:
+    """Update ``uid`` with given ``values`` and save."""
+    users = load_users()
+    user = users.get(uid)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    user.update(values)
+    save_users(users)
+
+
+def delete_user(uid: str) -> None:
+    """Remove ``uid`` from stored users."""
+    users = load_users()
+    if uid not in users:
+        raise HTTPException(status_code=404, detail="User not found")
+    users.pop(uid)
+    save_users(users)
+

--- a/backend/tests/test_server.py
+++ b/backend/tests/test_server.py
@@ -69,3 +69,18 @@ def test_cors_options(tmp_path):
     )
     assert r.status_code == 200
     assert r.headers.get("access-control-allow-origin") == "http://localhost:8080"
+
+
+def test_user_update_delete(tmp_path):
+    client = setup_env(tmp_path)
+    uid = client.post('/register', json={'username': 'alice', 'password': 'x'}).json()['uid']
+    r = client.put(f'/user/{uid}', json={'username': 'bob', 'age': 30, 'password': 'y'})
+    assert r.status_code == 200
+    data = json.load(open(tmp_path / 'user.json'))
+    assert data[uid]['username'] == 'bob'
+    assert data[uid]['age'] == 30
+    assert data[uid]['password'] == 'y'
+    r = client.delete(f'/user/{uid}')
+    assert r.status_code == 200
+    data = json.load(open(tmp_path / 'user.json'))
+    assert uid not in data

--- a/frontend/src/pages/UserStatusPage.vue
+++ b/frontend/src/pages/UserStatusPage.vue
@@ -1,0 +1,56 @@
+<template>
+  <q-page class="row items-center justify-center">
+    <div class="column q-gutter-sm" style="width: 300px">
+      <q-input v-model="username" label="Username" />
+      <q-input v-model.number="age" type="number" label="Age" />
+      <q-input v-model="password" type="password" label="New Password" />
+      <q-btn label="Save" color="primary" @click="save" />
+      <q-btn label="Delete Account" color="negative" @click="remove" />
+    </div>
+  </q-page>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import { useQuasar } from "quasar";
+import { useAuthStore } from "stores/authStore";
+import { useApiStore } from "stores/apiStore";
+
+const auth = useAuthStore();
+const api = useApiStore();
+api.init();
+
+const $q = useQuasar();
+
+const username = ref(auth.username);
+const age = ref(0);
+const password = ref("");
+
+auth.autoLogin();
+
+const save = async () => {
+  const data = { username: username.value, age: age.value };
+  if (password.value) data.password = password.value;
+  try {
+    await api.put(`/user/${auth.uid}`, data);
+    auth.username = username.value;
+    $q.notify({ type: "positive", message: "Updated" });
+  } catch (err) {
+    const msg = err.response?.data?.detail || err.message;
+    $q.notify({ type: "negative", message: msg });
+  }
+};
+
+const remove = async () => {
+  try {
+    await api.delete(`/user/${auth.uid}`);
+    auth.uid = null;
+    auth.username = "";
+    localStorage.removeItem("uid");
+    $q.notify({ type: "positive", message: "Account deleted" });
+  } catch (err) {
+    const msg = err.response?.data?.detail || err.message;
+    $q.notify({ type: "negative", message: msg });
+  }
+};
+</script>

--- a/frontend/src/router/routes.js
+++ b/frontend/src/router/routes.js
@@ -38,6 +38,11 @@ const routes = [
         name: "Chat",
         component: () => import("pages/ChatPage.vue"),
       },
+      {
+        path: "status",
+        name: "UserStatus",
+        component: () => import("pages/UserStatusPage.vue"),
+      },
     ],
   },
 

--- a/frontend/src/stores/appStore.js
+++ b/frontend/src/stores/appStore.js
@@ -34,6 +34,12 @@ export const useAppStore = defineStore("app", {
           route: "Register",
         },
         { titel: "Chat", caption: "chat", icon: "chat", route: "Chat" },
+        {
+          titel: "Status",
+          caption: "status",
+          icon: "person",
+          route: "UserStatus",
+        },
         { titel: "Impressum", caption: "", icon: "gavel", route: "Impressum" },
       ],
     };


### PR DESCRIPTION
## Summary
- add update and delete helpers for users
- expose `/user/{uid}` PUT and DELETE endpoints
- create `UserStatusPage` and link in router + nav
- test user update and delete flows

## Testing
- `PYTHONPATH=. pytest -q backend/tests/test_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68775f2177f08322b275ff63bce01e96