### PR TITLE
Add ping route and API status tooltip

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -10,6 +10,12 @@ from .services import friend_service, user_service
 
 app = FastAPI()
 
+
+@app.get("/ping")
+def ping():
+    """Health check endpoint."""
+    return {"status": "ok"}
+
 # Enable CORS for frontend requests
 app.add_middleware(
     CORSMiddleware,

--- a/backend/tests/test_server.py
+++ b/backend/tests/test_server.py
@@ -10,6 +10,12 @@ def setup_env(tmp_path):
     return TestClient(app)
 
 
+def test_ping(tmp_path):
+    client = setup_env(tmp_path)
+    r = client.get('/ping')
+    assert r.status_code == 200
+
+
 def test_register_login(tmp_path):
     client = setup_env(tmp_path)
     r = client.post('/register', json={'username': 'alice', 'password': 'x'})

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -51,7 +51,9 @@
     <q-page-container>
       <router-view />
       <q-page-sticky position="bottom-right" :offset="[18, 18]">
-        <q-icon name="circle" :color="apiColor" size="12px" />
+        <q-icon name="circle" :color="apiColor" size="12px">
+          <q-tooltip>{{ apiTooltip }}</q-tooltip>
+        </q-icon>
       </q-page-sticky>
     </q-page-container>
   </q-layout>
@@ -62,6 +64,7 @@ import EssentialLink from "components/EssentialLink.vue";
 import { useAppStore } from "stores/appStore";
 import { useErrorStore } from "stores/errorStore";
 import { useAuthStore } from "stores/authStore";
+import { useApiStore } from "stores/apiStore";
 
 export default {
   name: "MainLayout",
@@ -72,10 +75,12 @@ export default {
     const store = useAppStore();
     const errorStore = useErrorStore();
     const auth = useAuthStore();
-    return { store, errorStore, auth };
+    const apiStore = useApiStore();
+    return { store, errorStore, auth, apiStore };
   },
   mounted() {
     this.store.log("MainLayout.vue::mounted()");
+    this.apiStore.get("/ping").catch(() => {});
   },
   data() {
     return {
@@ -89,6 +94,10 @@ export default {
       if (this.errorStore.apiStatus === "ok") return "green";
       if (this.errorStore.apiStatus === "error") return "red";
       return "grey";
+    },
+    apiTooltip() {
+      if (this.errorStore.apiStatus === "ok") return "Server reachable";
+      return this.errorStore.lastError || "";
     },
   },
   methods: {

--- a/frontend/test/jest/__tests__/MainLayout.spec.js
+++ b/frontend/test/jest/__tests__/MainLayout.spec.js
@@ -4,18 +4,31 @@ import { mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import MainLayout from "layouts/MainLayout.vue";
 import { useAuthStore } from "stores/authStore";
+import { useErrorStore } from "stores/errorStore";
+
+jest.mock("stores/apiStore", () => {
+  const getMock = jest.fn();
+  return { useApiStore: () => ({ get: getMock }), getMock };
+});
+import { getMock } from "stores/apiStore";
 
 installQuasarPlugin();
 
 describe("MainLayout", () => {
   let wrapper;
   let store;
+  let errorStore;
 
   beforeEach(() => {
     const pinia = createPinia();
     setActivePinia(pinia);
     store = useAuthStore();
+    errorStore = useErrorStore();
     store.uid = "abc";
+    getMock.mockImplementation(() => {
+      errorStore.setOk();
+      return Promise.resolve({});
+    });
     wrapper = mount(MainLayout, {
       global: {
         plugins: [pinia],
@@ -32,5 +45,31 @@ describe("MainLayout", () => {
     const copy = wrapper.find('[data-testid="copy-btn"]');
     await copy.trigger("click");
     expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith("abc");
+  });
+
+  it("shows server reachable tooltip when ping succeeds", async () => {
+    await wrapper.vm.$nextTick();
+    expect(errorStore.apiStatus).toBe("ok");
+    expect(wrapper.vm.apiTooltip).toBe("Server reachable");
+  });
+
+  it("shows error tooltip when ping fails", async () => {
+    getMock.mockImplementation(() => {
+      errorStore.setError("fail");
+      return Promise.reject(new Error("fail"));
+    });
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    useAuthStore().uid = "abc";
+    errorStore = useErrorStore();
+    wrapper = mount(MainLayout, {
+      global: {
+        plugins: [pinia],
+        stubs: { EssentialLink: true, "router-view": true },
+      },
+    });
+    await wrapper.vm.$nextTick();
+    expect(errorStore.apiStatus).toBe("error");
+    expect(wrapper.vm.apiTooltip).toBe("fail");
   });
 });


### PR DESCRIPTION
## Summary
- implement `/ping` endpoint for backend
- call `/ping` on main layout mount to update API status
- display tooltip on API status icon with server health info
- add tests for ping endpoint and layout status behavior

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=. pytest backend/tests`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6877610fbf4083229b7899361084e83b