### PR TITLE
Add dynamic navigation links and logout

### DIFF
--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -37,6 +37,19 @@
           :key="link.title"
           :el="link"
         />
+        <q-item
+          v-if="auth.uid"
+          clickable
+          data-testid="logout-btn"
+          @click="logout"
+        >
+          <q-item-section avatar>
+            <q-icon name="logout" />
+          </q-item-section>
+          <q-item-section>
+            <q-item-label>Logout</q-item-label>
+          </q-item-section>
+        </q-item>
       </q-list>
       <div class="text-center q-pa-lg">
         <q-img
@@ -86,10 +99,12 @@ export default {
     return {
       toggleLeftDrawer: false,
       leftDrawerOpen: false,
-      essentialLinks: this.store.getEssentialLinks,
     };
   },
   computed: {
+    essentialLinks() {
+      return this.store.essentialLinks;
+    },
     apiColor() {
       if (this.errorStore.apiStatus === "ok") return "green";
       if (this.errorStore.apiStatus === "error") return "red";
@@ -105,6 +120,12 @@ export default {
       if (this.auth.uid) {
         navigator.clipboard.writeText(this.auth.uid);
       }
+    },
+    logout() {
+      this.auth.uid = null;
+      this.auth.username = "";
+      localStorage.removeItem("uid");
+      this.leftDrawerOpen = false;
     },
   },
 };

--- a/frontend/src/stores/appStore.js
+++ b/frontend/src/stores/appStore.js
@@ -1,4 +1,5 @@
 import { defineStore } from "pinia";
+import { useAuthStore } from "./authStore";
 
 export const useAppStore = defineStore("app", {
   state: () => {
@@ -16,7 +17,12 @@ export const useAppStore = defineStore("app", {
         quick_timer_start_value: 20, // in seconds
       },
       PINNED_TIMERS: pinnedTimers || [],
-      essentialLinks: [
+    };
+  },
+  getters: {
+    essentialLinks: () => {
+      const auth = useAuthStore();
+      const links = [
         { titel: "Home", caption: "zurück", icon: "home", route: "Index" },
         { seperator: true },
         { titel: "Über", caption: "about", icon: "info", route: "About" },
@@ -26,26 +32,30 @@ export const useAppStore = defineStore("app", {
           icon: "info",
           route: "ChangeLog",
         },
-        { titel: "Login", caption: "login", icon: "login", route: "Login" },
-        {
-          titel: "Register",
-          caption: "register",
-          icon: "person_add",
-          route: "Register",
-        },
-        { titel: "Chat", caption: "chat", icon: "chat", route: "Chat" },
-        {
+      ];
+      if (!auth.uid) {
+        links.push({
+          titel: "Login",
+          caption: "login",
+          icon: "login",
+          route: "Login",
+        });
+      } else {
+        links.push({
+          titel: "Chat",
+          caption: "chat",
+          icon: "chat",
+          route: "Chat",
+        });
+        links.push({
           titel: "Status",
           caption: "status",
           icon: "person",
           route: "UserStatus",
-        },
-        { titel: "Impressum", caption: "", icon: "gavel", route: "Impressum" },
-      ],
-    };
-  },
-  getters: {
-    getEssentialLinks: (state) => state.essentialLinks,
+        });
+      }
+      return links;
+    },
     env: () => ({
       APP_URL: process.env.APP_URL,
       APP_VERSION: process.env.APP_VERSION,


### PR DESCRIPTION
## Summary
- build `essentialLinks` dynamically based on authentication
- expose reactive links in `MainLayout`
- add logout entry in drawer

## Testing
- `npx prettier --write src/stores/appStore.js src/layouts/MainLayout.vue`
- `npx eslint src/stores/appStore.js src/layouts/MainLayout.vue`
- `npm run test:unit`
- `PYTHONPATH=. pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_68776a5d824c832281d09c18072917c3