### PR TITLE
Add logout menu

### DIFF
--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -16,12 +16,28 @@
         <q-space />
         <div v-if="auth.uid" class="row items-center">
           <span class="q-mr-xs">{{ auth.username }} ({{ auth.uid }})</span>
-          <q-icon
-            name="content_copy"
-            class="cursor-pointer"
-            data-testid="copy-btn"
-            @click="copyUid"
-          />
+          <q-btn label="Logged in" size="sm" data-testid="login-menu-btn">
+            <q-menu>
+              <q-list>
+                <q-item
+                  clickable
+                  v-close-popup
+                  data-testid="copy-btn"
+                  @click="copyUid"
+                >
+                  <q-item-section>Copy UID</q-item-section>
+                </q-item>
+                <q-item
+                  clickable
+                  v-close-popup
+                  data-testid="logout-btn"
+                  @click="logout"
+                >
+                  <q-item-section>Logout</q-item-section>
+                </q-item>
+              </q-list>
+            </q-menu>
+          </q-btn>
         </div>
       </q-toolbar>
     </q-header>
@@ -37,19 +53,6 @@
           :key="link.title"
           :el="link"
         />
-        <q-item
-          v-if="auth.uid"
-          clickable
-          data-testid="logout-btn"
-          @click="logout"
-        >
-          <q-item-section avatar>
-            <q-icon name="logout" />
-          </q-item-section>
-          <q-item-section>
-            <q-item-label>Logout</q-item-label>
-          </q-item-section>
-        </q-item>
       </q-list>
       <div class="text-center q-pa-lg">
         <q-img

--- a/frontend/test/jest/__tests__/MainLayout.spec.js
+++ b/frontend/test/jest/__tests__/MainLayout.spec.js
@@ -42,9 +42,23 @@ describe("MainLayout", () => {
   });
 
   it("copies uid to clipboard", async () => {
-    const copy = wrapper.find('[data-testid="copy-btn"]');
+    const btn = wrapper.get('[data-testid="login-menu-btn"]');
+    await btn.trigger("click");
+    const copy = wrapper.get('[data-testid="copy-btn"]');
     await copy.trigger("click");
     expect(global.navigator.clipboard.writeText).toHaveBeenCalledWith("abc");
+  });
+
+  it("clears auth data on logout", async () => {
+    store.username = "user";
+    localStorage.setItem("uid", "abc");
+    const btn = wrapper.get('[data-testid="login-menu-btn"]');
+    await btn.trigger("click");
+    const logout = wrapper.get('[data-testid="logout-btn"]');
+    await logout.trigger("click");
+    expect(store.uid).toBeNull();
+    expect(store.username).toBe("");
+    expect(localStorage.getItem("uid")).toBeNull();
   });
 
   it("shows server reachable tooltip when ping succeeds", async () => {


### PR DESCRIPTION
## Summary
- show a 'Logged in' button that opens a menu
- allow copying the UID or logging out
- test copy and logout behaviour in MainLayout

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68776c335b548322847011cab5bb016a