### PR TITLE
Add headers to auth pages

### DIFF
--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -1,5 +1,6 @@
 <template>
   <q-page class="row items-center justify-center">
+    <div class="text-h5 q-mb-md">Login</div>
     <div class="column q-gutter-sm" style="width: 300px">
       <q-input v-model="username" label="Username" />
       <q-input v-model="password" type="password" label="Password" />

--- a/frontend/src/pages/RegisterPage.vue
+++ b/frontend/src/pages/RegisterPage.vue
@@ -1,5 +1,6 @@
 <template>
   <q-page class="row items-center justify-center">
+    <div class="text-h5 q-mb-md">Register</div>
     <div class="column q-gutter-sm" style="width: 300px">
       <q-input v-model="username" label="Username" />
       <q-input v-model="password" type="password" label="Password" />

--- a/frontend/src/pages/UserStatusPage.vue
+++ b/frontend/src/pages/UserStatusPage.vue
@@ -1,5 +1,6 @@
 <template>
   <q-page class="row items-center justify-center">
+    <div class="text-h5 q-mb-md">User Status</div>
     <div class="column q-gutter-sm" style="width: 300px">
       <q-input v-model="username" label="Username" />
       <q-input v-model.number="age" type="number" label="Age" />

--- a/frontend/test/jest/__tests__/LoginPage.spec.js
+++ b/frontend/test/jest/__tests__/LoginPage.spec.js
@@ -21,7 +21,7 @@ describe("LoginPage", () => {
     wrapper = shallowMount(LoginPage, {
       global: {
         plugins: [pinia],
-        stubs: { "q-page": true, "q-input": true, "q-btn": true },
+        stubs: { "q-input": true, "q-btn": true },
       },
     });
     notifyMock = jest.fn();
@@ -55,5 +55,11 @@ describe("LoginPage", () => {
     wrapper.vm.password = "p";
     await wrapper.vm.doRegister();
     expect(store.register).toHaveBeenCalledWith("u", "p");
+  });
+
+  it("renders header", () => {
+    const header = wrapper.find(".text-h5");
+    expect(header.exists()).toBe(true);
+    expect(header.text()).toBe("Login");
   });
 });

--- a/frontend/test/jest/__tests__/RegisterPage.spec.js
+++ b/frontend/test/jest/__tests__/RegisterPage.spec.js
@@ -25,7 +25,7 @@ describe("RegisterPage", () => {
     wrapper = shallowMount(RegisterPage, {
       global: {
         plugins: [pinia, router],
-        stubs: { "q-page": true, "q-input": true, "q-btn": true },
+        stubs: { "q-input": true, "q-btn": true },
       },
     });
     notifyMock = jest.fn();
@@ -55,5 +55,11 @@ describe("RegisterPage", () => {
     wrapper.vm.passwordConfirm = "p";
     await wrapper.vm.doRegister();
     expect(routerPush).toHaveBeenCalledWith({ name: "Login" });
+  });
+
+  it("renders header", () => {
+    const header = wrapper.find(".text-h5");
+    expect(header.exists()).toBe(true);
+    expect(header.text()).toBe("Register");
   });
 });

--- a/frontend/test/jest/__tests__/UserStatusPage.spec.js
+++ b/frontend/test/jest/__tests__/UserStatusPage.spec.js
@@ -1,0 +1,35 @@
+import { beforeEach, describe, it, expect, jest } from "@jest/globals";
+import { installQuasarPlugin } from "@quasar/quasar-app-extension-testing-unit-jest";
+import { shallowMount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import UserStatusPage from "pages/UserStatusPage.vue";
+import { useAuthStore } from "stores/authStore";
+
+jest.mock("stores/apiStore", () => ({
+  useApiStore: () => ({ init: jest.fn() }),
+}));
+
+installQuasarPlugin();
+
+describe("UserStatusPage", () => {
+  let wrapper;
+  let store;
+
+  beforeEach(() => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    store = useAuthStore();
+    wrapper = shallowMount(UserStatusPage, {
+      global: {
+        plugins: [pinia],
+        stubs: { "q-input": true, "q-btn": true },
+      },
+    });
+  });
+
+  it("renders header", () => {
+    const header = wrapper.find(".text-h5");
+    expect(header.exists()).toBe(true);
+    expect(header.text()).toBe("User Status");
+  });
+});


### PR DESCRIPTION
## Summary
- add text headers to Login/Register/UserStatus pages
- verify presence via unit tests

## Testing
- `npm run lint`
- `npm run test:unit`
- `PYTHONPATH=. pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_68776ed10d148322bd32d76d65d2fa9a