### PR TITLE
Implement auto login restore

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -117,6 +117,13 @@ def login(payload: dict):
     raise HTTPException(status_code=401, detail='Invalid credentials')
 
 
+@app.get('/user/{uid}')
+def get_user(uid: str):
+    """Return stored user information."""
+    user = user_service.get_user(uid)
+    return user
+
+
 @app.put('/user/{uid}')
 def update_user(uid: str, payload: dict):
     """Modify an existing user."""

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -39,6 +39,15 @@ def load_users():
     return _load_json(users_file(), {})
 
 
+def get_user(uid: str) -> dict:
+    """Return stored user with ``uid``."""
+    users = load_users()
+    user = users.get(uid)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
 def save_users(data):
     """Persist user dictionary to disk."""
     _save_json(users_file(), data)

--- a/backend/tests/test_server.py
+++ b/backend/tests/test_server.py
@@ -28,6 +28,16 @@ def test_register_login(tmp_path):
     assert uid in data
 
 
+def test_user_get(tmp_path):
+    client = setup_env(tmp_path)
+    uid = client.post('/register', json={'username': 'alice', 'password': 'x'}).json()['uid']
+    r = client.get(f'/user/{uid}')
+    assert r.status_code == 200
+    data = r.json()
+    assert data['uid'] == uid
+    assert data['username'] == 'alice'
+
+
 def test_friend_request_accept(tmp_path):
     client = setup_env(tmp_path)
     u1 = client.post('/register', json={'username': 'a', 'password': 'p'}).json()['uid']

--- a/frontend/quasar.config.js
+++ b/frontend/quasar.config.js
@@ -8,46 +8,36 @@
 // Configuration for your app
 // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js
 
-import { configure } from 'quasar/wrappers';
+import { configure } from "quasar/wrappers";
 
 export default configure(function (ctx) {
   return {
     env: {
       APP_URL: process.env.APP_URL,
       APP_VERSION: process.env.APP_VERSION,
-      APP_NAME: process.env.APP_NAME
+      APP_NAME: process.env.APP_NAME,
     },
 
     supportTS: false,
 
-    boot: [
-      'pinia',
-      'axios',
-      'logger',
-      'firebase'
-    ],
+    boot: ["pinia", "autologin", "axios", "logger", "firebase"],
 
-    css: [
-      'app.scss'
-    ],
+    css: ["app.scss"],
 
-    extras: [
-      'roboto-font',
-      'material-icons'
-    ],
+    extras: ["roboto-font", "material-icons"],
 
     build: {
-      vueRouterMode: 'hash'
+      vueRouterMode: "hash",
     },
 
     devServer: {
       port: 8080,
-      open: true
+      open: true,
     },
 
     framework: {
       config: {},
-      plugins: ['Notify', 'Dialog']
+      plugins: ["Notify", "Dialog"],
     },
 
     animations: [],
@@ -56,68 +46,65 @@ export default configure(function (ctx) {
       pwa: false,
       prodPort: 3000,
       maxAge: 1000 * 60 * 60 * 24 * 30,
-      middlewares: [
-        ctx.prod ? 'compression' : '',
-        'render'
-      ]
+      middlewares: [ctx.prod ? "compression" : "", "render"],
     },
 
     pwa: {
-      workboxPluginMode: 'GenerateSW',
+      workboxPluginMode: "GenerateSW",
       workboxOptions: {},
 
       manifest: {
         name: `Quasar App`,
         short_name: `Quasar App`,
         description: `A Quasar Project`,
-        display: 'standalone',
-        orientation: 'portrait',
-        background_color: '#ffffff',
-        theme_color: '#027be3',
+        display: "standalone",
+        orientation: "portrait",
+        background_color: "#ffffff",
+        theme_color: "#027be3",
         icons: [
           {
-            src: 'icons/icon-128x128.png',
-            sizes: '128x128',
-            type: 'image/png'
+            src: "icons/icon-128x128.png",
+            sizes: "128x128",
+            type: "image/png",
           },
           {
-            src: 'icons/icon-192x192.png',
-            sizes: '192x192',
-            type: 'image/png'
+            src: "icons/icon-192x192.png",
+            sizes: "192x192",
+            type: "image/png",
           },
           {
-            src: 'icons/icon-256x256.png',
-            sizes: '256x256',
-            type: 'image/png'
+            src: "icons/icon-256x256.png",
+            sizes: "256x256",
+            type: "image/png",
           },
           {
-            src: 'icons/icon-384x384.png',
-            sizes: '384x384',
-            type: 'image/png'
+            src: "icons/icon-384x384.png",
+            sizes: "384x384",
+            type: "image/png",
           },
           {
-            src: 'icons/icon-512x512.png',
-            sizes: '512x512',
-            type: 'image/png'
-          }
-        ]
-      }
+            src: "icons/icon-512x512.png",
+            sizes: "512x512",
+            type: "image/png",
+          },
+        ],
+      },
     },
 
     cordova: {},
 
     capacitor: {
-      hideSplashscreen: true
+      hideSplashscreen: true,
     },
 
     electron: {
-      bundler: 'packager',
+      bundler: "packager",
 
       packager: {},
 
       builder: {
-        appId: 'sportsfreund2'
-      }
-    }
-  }
+        appId: "sportsfreund2",
+      },
+    },
+  };
 });

--- a/frontend/src/boot/autologin.js
+++ b/frontend/src/boot/autologin.js
@@ -1,0 +1,7 @@
+import { boot } from "quasar/wrappers";
+import { useAuthStore } from "stores/authStore";
+
+export default boot(async () => {
+  const auth = useAuthStore();
+  await auth.autoLogin();
+});

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -128,6 +128,8 @@ export default {
       this.auth.uid = null;
       this.auth.username = "";
       localStorage.removeItem("uid");
+      localStorage.removeItem("username");
+      localStorage.removeItem("password");
       this.leftDrawerOpen = false;
     },
   },

--- a/frontend/src/pages/UserStatusPage.vue
+++ b/frontend/src/pages/UserStatusPage.vue
@@ -48,6 +48,8 @@ const remove = async () => {
     auth.uid = null;
     auth.username = "";
     localStorage.removeItem("uid");
+    localStorage.removeItem("username");
+    localStorage.removeItem("password");
     $q.notify({ type: "positive", message: "Account deleted" });
   } catch (err) {
     const msg = err.response?.data?.detail || err.message;

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -14,6 +14,8 @@ export const useAuthStore = defineStore("auth", {
         this.uid = res.data.uid;
         this.username = username;
         localStorage.setItem("uid", this.uid);
+        localStorage.setItem("username", username);
+        if (password) localStorage.setItem("password", password);
       } catch (err) {
         throw err;
       }
@@ -25,13 +27,31 @@ export const useAuthStore = defineStore("auth", {
         this.uid = res.data.uid;
         this.username = username;
         localStorage.setItem("uid", this.uid);
+        localStorage.setItem("username", username);
+        if (password) localStorage.setItem("password", password);
       } catch (err) {
         throw err;
       }
     },
-    autoLogin() {
+    async autoLogin() {
       const id = localStorage.getItem("uid");
-      if (id) this.uid = id;
+      if (!id) return;
+      this.uid = id;
+      const name = localStorage.getItem("username");
+      if (name) {
+        this.username = name;
+        return;
+      }
+      const api = useApiStore();
+      try {
+        const res = await api.get(`/user/${id}`);
+        if (res.data && res.data.username) {
+          this.username = res.data.username;
+          localStorage.setItem("username", this.username);
+        }
+      } catch (err) {
+        // ignore errors
+      }
     },
     async sendFriendRequest(friend_uid) {
       const api = useApiStore();

--- a/frontend/test/jest/__tests__/MainLayout.spec.js
+++ b/frontend/test/jest/__tests__/MainLayout.spec.js
@@ -52,6 +52,7 @@ describe("MainLayout", () => {
   it("clears auth data on logout", async () => {
     store.username = "user";
     localStorage.setItem("uid", "abc");
+    localStorage.setItem("username", "user");
     const btn = wrapper.get('[data-testid="login-menu-btn"]');
     await btn.trigger("click");
     const logout = wrapper.get('[data-testid="logout-btn"]');
@@ -59,6 +60,7 @@ describe("MainLayout", () => {
     expect(store.uid).toBeNull();
     expect(store.username).toBe("");
     expect(localStorage.getItem("uid")).toBeNull();
+    expect(localStorage.getItem("username")).toBeNull();
   });
 
   it("shows server reachable tooltip when ping succeeds", async () => {


### PR DESCRIPTION
## Summary
- store username and password in localStorage on login or registration
- fetch username through new `/user/{uid}` endpoint
- run auto login on startup via boot file
- wipe credentials on logout or account removal
- cover new behaviour with unit tests

## Testing
- `npx prettier -w frontend/quasar.config.js frontend/src/boot/autologin.js frontend/src/layouts/MainLayout.vue frontend/src/pages/UserStatusPage.vue frontend/src/stores/authStore.js frontend/test/jest/__tests__/authStore.spec.js frontend/test/jest/__tests__/MainLayout.spec.js`
- `npx eslint quasar.config.js src/boot/autologin.js src/layouts/MainLayout.vue src/pages/UserStatusPage.vue src/stores/authStore.js test/jest/__tests__/authStore.spec.js test/jest/__tests__/MainLayout.spec.js`
- `npm run test:unit`
- `PYTHONPATH=. pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68777944b64c8322ba9578db2da2f6fd