### PR TITLE
Fix websocket backend support

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
-uvicorn
-httpx
+uvicorn[standard]
+httpx>=0.24,<0.28
+websockets


### PR DESCRIPTION
## Summary
- ensure websockets library is installed
- pin httpx version for test compatibility

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=. pytest backend/tests`
- `npm run test:unit` *(fails: api.get is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6877924574f88322b04ca91ea88b745c