### PR TITLE
Refactor chat page with new components

### DIFF
--- a/frontend/src/components/ChatInvite.vue
+++ b/frontend/src/components/ChatInvite.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="row q-gutter-sm items-end">
+    <q-input
+      v-model="uid"
+      label="Friend UID"
+      input-class="text-white"
+      label-color="grey-7"
+    />
+    <q-btn label="Send" color="primary" @click="sendRequest" />
+    <q-btn label="Accept" color="primary" @click="acceptRequest" />
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import { useQuasar } from "quasar";
+import { useAuthStore } from "stores/authStore";
+
+const emit = defineEmits(["added"]);
+
+const uid = ref("");
+const $q = useQuasar();
+const auth = useAuthStore();
+
+async function handle(action) {
+  if (!uid.value) return;
+  try {
+    await action(uid.value);
+    emit("added", uid.value);
+    $q.notify({ type: "positive", message: "Request sent" });
+  } catch (err) {
+    const msg = err.response?.data?.detail || err.message;
+    $q.notify({ type: "negative", message: msg });
+  }
+}
+
+const sendRequest = () => handle(auth.sendFriendRequest);
+const acceptRequest = () => handle(auth.acceptFriend);
+</script>

--- a/frontend/src/components/ChatList.vue
+++ b/frontend/src/components/ChatList.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="column q-gutter-sm items-center" style="max-width: 300px">
+    <q-select
+      v-model="model"
+      :options="friends"
+      label="Friend UID"
+      input-class="text-white"
+      label-color="grey-7"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+  modelValue: String,
+  friends: { type: Array, default: () => [] },
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+const model = computed({
+  get: () => props.modelValue,
+  set: (val) => emit("update:modelValue", val),
+});
+</script>

--- a/frontend/src/components/ChatWindow.vue
+++ b/frontend/src/components/ChatWindow.vue
@@ -1,0 +1,50 @@
+<template>
+  <div v-if="friend" class="q-mt-md">
+    <div
+      class="q-pa-sm"
+      style="height: 200px; overflow: auto; border: 1px solid #ccc"
+    >
+      <div v-for="m in messages" :key="m.time" class="text-white">
+        <span class="text-bold">{{ m.from }}</span
+        >: {{ m.text }}
+      </div>
+    </div>
+    <div class="row q-gutter-sm q-mt-sm">
+      <q-form @submit.prevent="onSubmit" class="row q-gutter-sm">
+        <q-input
+          v-model="text"
+          label="Message"
+          input-class="text-white"
+          label-color="grey-7"
+        />
+        <q-btn icon="send" type="submit" color="primary" />
+      </q-form>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from "vue";
+
+const props = defineProps({
+  friend: String,
+  messages: { type: Array, default: () => [] },
+});
+
+const emit = defineEmits(["send"]);
+
+const text = ref("");
+
+const onSubmit = () => {
+  if (!text.value) return;
+  emit("send", text.value);
+  text.value = "";
+};
+
+watch(
+  () => props.friend,
+  () => {
+    text.value = "";
+  },
+);
+</script>

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -1,37 +1,14 @@
 <template>
   <q-page class="column items-center q-pa-md">
-    <div class="column q-gutter-sm items-center" style="max-width: 300px">
-      <q-select
-        v-model="friend"
-        :options="friends"
-        label="Friend UID"
-        input-class="text-white"
-        label-color="grey-7"
-      />
-      <q-btn label="Open Chat" color="primary" @click="connect" />
-    </div>
-    <div class="q-mt-md" v-if="connected && friend">
-      <div
-        class="q-pa-sm"
-        style="height: 200px; overflow: auto; border: 1px solid #ccc"
-      >
-        <div v-for="m in messages" :key="m.time" class="text-white">
-          <span class="text-bold">{{ m.from }}</span
-          >: {{ m.text }}
-        </div>
-      </div>
-      <div class="row q-gutter-sm q-mt-sm">
-        <q-form @submit="send" class="row q-gutter-sm">
-          <q-input
-            v-model="text"
-            label="Message"
-            input-class="text-white"
-            label-color="grey-7"
-          />
-          <q-btn icon="send" type="submit" color="primary" />
-        </q-form>
-      </div>
-    </div>
+    <chat-invite class="q-mb-md" @added="onInvite" />
+    <chat-list v-model="friend" :friends="friends" />
+    <chat-window
+      v-if="connected && friend"
+      class="q-mt-md"
+      :friend="friend"
+      :messages="messages"
+      @send="send"
+    />
   </q-page>
 </template>
 
@@ -40,13 +17,15 @@ import { ref, reactive, onMounted, watch } from "vue";
 import { useQuasar } from "quasar";
 import { useAuthStore } from "stores/authStore";
 import { useApiStore } from "stores/apiStore";
+import ChatInvite from "components/ChatInvite.vue";
+import ChatList from "components/ChatList.vue";
+import ChatWindow from "components/ChatWindow.vue";
 
 const store = useAuthStore();
 const api = useApiStore();
 const $q = useQuasar();
 const friend = ref("");
 const friends = ref([]);
-const text = ref("");
 const messages = ref([]);
 const histories = reactive({});
 const connected = ref(false);
@@ -102,30 +81,22 @@ const loadHistory = async (fid) => {
   }
 };
 
-const connect = async () => {
-  if (!friend.value) return;
-  try {
-    await store.sendFriendRequest(friend.value);
-    await store.acceptFriend(friend.value);
-  } catch (err) {
-    const msg = err.response?.data?.detail || err.message;
-    $q.notify({ type: "negative", message: msg });
-    return;
-  }
-  await loadHistory(friend.value);
-};
-
 watch(friend, (val) => {
   if (val) loadHistory(val);
 });
 
-const send = () => {
+const send = (msg) => {
   if (!ws || !friend.value) return;
-  ws.send(JSON.stringify({ to: friend.value, message: text.value }));
-  const selfMsg = { from: store.uid, text: text.value, time: Date.now() };
+  ws.send(JSON.stringify({ to: friend.value, message: msg }));
+  const selfMsg = { from: store.uid, text: msg, time: Date.now() };
   if (!histories[friend.value]) histories[friend.value] = [];
   histories[friend.value].push(selfMsg);
   messages.value.push(selfMsg);
-  text.value = "";
+};
+
+const onInvite = async (uid) => {
+  if (!friends.value.includes(uid)) friends.value.push(uid);
+  friend.value = uid;
+  await loadHistory(uid);
 };
 </script>


### PR DESCRIPTION
## Summary
- break chat page into ChatInvite, ChatList and ChatWindow components
- integrate new components into ChatPage

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: Jest worker encountered 4 child process exceptions)*
- `PYTHONPATH=. pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6877a6d0463083229bd4ec8d2732f191