### PR TITLE
Implement chat store

### DIFF
--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -13,90 +13,31 @@
 </template>
 
 <script setup>
-import { ref, reactive, onMounted, watch } from "vue";
-import { useQuasar } from "quasar";
-import { useAuthStore } from "stores/authStore";
-import { useApiStore } from "stores/apiStore";
+import { onMounted, watch } from "vue";
+import { storeToRefs } from "pinia";
+import { useChatStore } from "stores/chatStore";
 import ChatInvite from "components/ChatInvite.vue";
 import ChatList from "components/ChatList.vue";
 import ChatWindow from "components/ChatWindow.vue";
 
-const store = useAuthStore();
-const api = useApiStore();
-const $q = useQuasar();
-const friend = ref("");
-const friends = ref([]);
-const messages = ref([]);
-const histories = reactive({});
-const connected = ref(false);
-let ws;
-
-const openSocket = () => {
-  ws = new WebSocket(`ws://localhost:8000/ws/${store.uid}`);
-  ws.onmessage = (e) => {
-    const data = JSON.parse(e.data);
-    if (data.event === "chat_request") {
-      if (!friends.value.includes(data.from)) friends.value.push(data.from);
-      $q.notify({ type: "info", message: `Chat request from ${data.from}` });
-      return;
-    }
-    const msg = { from: data.from, text: data.message, time: Date.now() };
-    if (!histories[data.from]) histories[data.from] = [];
-    histories[data.from].push(msg);
-    if (friend.value === data.from) messages.value.push(msg);
-  };
-  ws.onopen = () => {
-    connected.value = true;
-  };
-  ws.onerror = () => {
-    $q.notify({ type: "negative", message: "WebSocket error" });
-  };
-  ws.onclose = (e) => {
-    connected.value = false;
-    $q.notify({ type: "negative", message: e.reason || "Connection closed" });
-  };
-};
+const chat = useChatStore();
+const { friend, friends, messages, connected } = storeToRefs(chat);
 
 onMounted(async () => {
-  await store.autoLogin();
-  api.init && api.init();
-  if (store.uid) {
-    openSocket();
-    try {
-      const res = await api.get(`/user/${store.uid}`);
-      friends.value = res.data.friends || [];
-    } catch (err) {
-      // ignore
-    }
-  }
+  await chat.connect();
 });
 
-const loadHistory = async (fid) => {
-  try {
-    const res = await api.get(`/messages/${store.uid}/${fid}`);
-    histories[fid] = res.data || [];
-    messages.value = histories[fid];
-  } catch (err) {
-    histories[fid] = [];
-  }
-};
-
 watch(friend, (val) => {
-  if (val) loadHistory(val);
+  if (val) chat.loadHistory(val);
 });
 
 const send = (msg) => {
-  if (!ws || !friend.value) return;
-  ws.send(JSON.stringify({ to: friend.value, message: msg }));
-  const selfMsg = { from: store.uid, text: msg, time: Date.now() };
-  if (!histories[friend.value]) histories[friend.value] = [];
-  histories[friend.value].push(selfMsg);
-  messages.value.push(selfMsg);
+  chat.send(msg);
 };
 
 const onInvite = async (uid) => {
   if (!friends.value.includes(uid)) friends.value.push(uid);
   friend.value = uid;
-  await loadHistory(uid);
+  await chat.loadHistory(uid);
 };
 </script>

--- a/frontend/src/stores/chatStore.js
+++ b/frontend/src/stores/chatStore.js
@@ -1,0 +1,84 @@
+import { defineStore } from "pinia";
+import { Notify } from "quasar";
+import { useAuthStore } from "./authStore";
+import { useApiStore } from "./apiStore";
+
+export const useChatStore = defineStore("chat", {
+  state: () => ({
+    ws: null,
+    connected: false,
+    friends: [],
+    friend: "",
+    histories: {},
+    messages: [],
+  }),
+  actions: {
+    openSocket() {
+      const auth = useAuthStore();
+      this.ws = new WebSocket(`ws://localhost:8000/ws/${auth.uid}`);
+      this.ws.onmessage = (e) => {
+        const data = JSON.parse(e.data);
+        if (data.event === "chat_request") {
+          if (!this.friends.includes(data.from)) this.friends.push(data.from);
+          Notify.create({
+            type: "info",
+            message: `Chat request from ${data.from}`,
+          });
+          return;
+        }
+        const msg = { from: data.from, text: data.message, time: Date.now() };
+        if (!this.histories[data.from]) this.histories[data.from] = [];
+        this.histories[data.from].push(msg);
+        if (this.friend === data.from) this.messages.push(msg);
+      };
+      this.ws.onopen = () => {
+        this.connected = true;
+      };
+      this.ws.onerror = () => {
+        Notify.create({ type: "negative", message: "WebSocket error" });
+      };
+      this.ws.onclose = (e) => {
+        this.connected = false;
+        Notify.create({
+          type: "negative",
+          message: e.reason || "Connection closed",
+        });
+      };
+    },
+    async connect() {
+      const auth = useAuthStore();
+      const api = useApiStore();
+      await auth.autoLogin();
+      api.init && api.init();
+      if (auth.uid) {
+        this.openSocket();
+        try {
+          const res = await api.get(`/user/${auth.uid}`);
+          this.friends = res.data.friends || [];
+        } catch (err) {
+          // ignore
+        }
+      }
+    },
+    async loadHistory(fid) {
+      const auth = useAuthStore();
+      const api = useApiStore();
+      try {
+        const res = await api.get(`/messages/${auth.uid}/${fid}`);
+        this.histories[fid] = res.data || [];
+        if (this.friend === fid) this.messages = this.histories[fid];
+      } catch (err) {
+        this.histories[fid] = [];
+      }
+    },
+    send(msg) {
+      const auth = useAuthStore();
+      if (!this.ws || !this.friend) return;
+      this.ws.send(JSON.stringify({ to: this.friend, message: msg }));
+      const selfMsg = { from: auth.uid, text: msg, time: Date.now() };
+      if (!this.histories[this.friend]) this.histories[this.friend] = [];
+      this.histories[this.friend].push(selfMsg);
+      this.messages.push(selfMsg);
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- create `chatStore` to manage socket state and chats
- refactor `ChatPage` to use new store

## Testing
- `npm run format`
- `npm run lint`
- `npm run test:unit` *(fails: 4 failed, 11 passed)*
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6877ac8dc018832283cbcc851fe03cfd