### PR TITLE
Add chat store API actions

### DIFF
--- a/frontend/src/components/ChatInvite.vue
+++ b/frontend/src/components/ChatInvite.vue
@@ -14,13 +14,13 @@
 <script setup>
 import { ref } from "vue";
 import { useQuasar } from "quasar";
-import { useAuthStore } from "stores/authStore";
+import { useChatStore } from "stores/chatStore";
 
 const emit = defineEmits(["added"]);
 
 const uid = ref("");
 const $q = useQuasar();
-const auth = useAuthStore();
+const chat = useChatStore();
 
 async function handle(action) {
   if (!uid.value) return;
@@ -34,6 +34,6 @@ async function handle(action) {
   }
 }
 
-const sendRequest = () => handle(auth.sendFriendRequest);
-const acceptRequest = () => handle(auth.acceptFriend);
+const sendRequest = () => handle(chat.sendFriendRequest);
+const acceptRequest = () => handle(chat.acceptFriend);
 </script>

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -28,7 +28,7 @@ onMounted(async () => {
 });
 
 watch(friend, (val) => {
-  if (val) chat.loadHistory(val);
+  if (val) chat.fetchHistory(val);
 });
 
 const send = (msg) => {
@@ -38,6 +38,6 @@ const send = (msg) => {
 const onInvite = async (uid) => {
   if (!friends.value.includes(uid)) friends.value.push(uid);
   friend.value = uid;
-  await chat.loadHistory(uid);
+  await chat.fetchHistory(uid);
 };
 </script>

--- a/frontend/src/stores/chatStore.js
+++ b/frontend/src/stores/chatStore.js
@@ -60,7 +60,7 @@ export const useChatStore = defineStore("chat", {
         }
       }
     },
-    async loadHistory(fid) {
+    async fetchHistory(fid) {
       const auth = useAuthStore();
       const api = useApiStore();
       try {
@@ -70,6 +70,16 @@ export const useChatStore = defineStore("chat", {
       } catch (err) {
         this.histories[fid] = [];
       }
+    },
+    async sendFriendRequest(friend_uid) {
+      const auth = useAuthStore();
+      const api = useApiStore();
+      await api.post("/friend/request", { uid: auth.uid, friend_uid });
+    },
+    async acceptFriend(friend_uid) {
+      const auth = useAuthStore();
+      const api = useApiStore();
+      await api.post("/friend/accept", { uid: auth.uid, friend_uid });
     },
     send(msg) {
       const auth = useAuthStore();


### PR DESCRIPTION
## Summary
- add `sendFriendRequest`, `acceptFriend`, and `fetchHistory` actions to chat store
- adjust chat page to use the new `fetchHistory` action
- update chat invite component to call chat store actions instead of auth store

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: ChatPage and UserStatusPage tests)*
- `PYTHONPATH=. pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_6877b5a1fec48322b9b99c57dda2760d