### PR TITLE
Implement chat request queue

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -170,6 +170,15 @@ def friend_accept(payload: dict):
     return {'status': 'accepted'}
 
 
+@app.post('/friend/decline')
+def friend_decline(payload: dict):
+    uid = payload['uid']
+    friend_uid = payload['friend_uid']
+    friend_service.decline_request(uid, friend_uid)
+    log_event({'event': 'friend_decline', 'uid': uid, 'friend_uid': friend_uid})
+    return {'status': 'declined'}
+
+
 @app.get('/messages/{uid}/{friend_uid}')
 def get_messages(uid: str, friend_uid: str):
     room = message_service.room_id(uid, friend_uid)

--- a/backend/services/friend_service.py
+++ b/backend/services/friend_service.py
@@ -26,3 +26,14 @@ def accept_request(uid: str, friend_uid: str) -> None:
         user.setdefault("friends", []).append(friend_uid)
         friend.setdefault("friends", []).append(uid)
     save_users(users)
+
+
+def decline_request(uid: str, friend_uid: str) -> None:
+    """Decline a friend request for ``uid`` from ``friend_uid``."""
+    users = load_users()
+    user = users.get(uid)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    if friend_uid in user.get("requests", []):
+        user["requests"].remove(friend_uid)
+    save_users(users)

--- a/backend/tests/test_server.py
+++ b/backend/tests/test_server.py
@@ -51,8 +51,22 @@ def test_friend_request_accept(tmp_path):
     assert u1 in users[u2]['requests']
     client.post('/friend/accept', json={'uid': u2, 'friend_uid': u1})
     users = json.load(open(tmp_path/'user.json'))
+    assert u1 not in users[u2]['requests']
     assert u1 in users[u2]['friends']
     assert u2 in users[u1]['friends']
+
+
+def test_friend_request_decline(tmp_path):
+    client = setup_env(tmp_path)
+    u1 = client.post('/register', json={'username': 'a', 'password': 'p'}).json()['uid']
+    u2 = client.post('/register', json={'username': 'b', 'password': 'p'}).json()['uid']
+    client.post('/friend/request', json={'uid': u1, 'friend_uid': u2})
+    users = json.load(open(tmp_path/'user.json'))
+    assert u1 in users[u2]['requests']
+    client.post('/friend/decline', json={'uid': u2, 'friend_uid': u1})
+    users = json.load(open(tmp_path/'user.json'))
+    assert u1 not in users[u2].get('requests', [])
+    assert u1 not in users[u2].get('friends', [])
 
 
 def test_websocket_chat(tmp_path):

--- a/frontend/src/components/ChatRequests.vue
+++ b/frontend/src/components/ChatRequests.vue
@@ -1,0 +1,28 @@
+<template>
+  <div v-if="requests.length" class="column q-gutter-sm">
+    <div
+      v-for="uid in requests"
+      :key="uid"
+      class="row q-gutter-sm items-center"
+    >
+      <span class="text-white">{{ uid }}</span>
+      <q-btn label="Accept" size="sm" color="primary" @click="accept(uid)" />
+      <q-btn label="Decline" size="sm" color="negative" @click="decline(uid)" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { storeToRefs } from 'pinia'
+import { useChatStore } from 'stores/chatStore'
+
+const chat = useChatStore()
+const { requests } = storeToRefs(chat)
+
+const accept = (uid) => {
+  chat.acceptRequest(uid)
+}
+const decline = (uid) => {
+  chat.declineRequest(uid)
+}
+</script>

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -1,6 +1,7 @@
 <template>
   <q-page class="column items-center q-pa-md">
     <chat-invite class="q-mb-md" @added="onInvite" />
+    <chat-requests class="q-mb-md" />
     <chat-list v-model="friend" :friends="friends" />
     <chat-window
       v-if="connected && friend"
@@ -17,6 +18,7 @@ import { onMounted, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { useChatStore } from "stores/chatStore";
 import ChatInvite from "components/ChatInvite.vue";
+import ChatRequests from "components/ChatRequests.vue";
 import ChatList from "components/ChatList.vue";
 import ChatWindow from "components/ChatWindow.vue";
 

--- a/frontend/test/jest/__tests__/chatStore.spec.js
+++ b/frontend/test/jest/__tests__/chatStore.spec.js
@@ -1,0 +1,55 @@
+import { beforeEach, describe, it, expect, jest } from "@jest/globals";
+import { createPinia, setActivePinia } from "pinia";
+import { useChatStore } from "stores/chatStore";
+import { useAuthStore } from "stores/authStore";
+import { Notify } from "quasar";
+
+jest.mock("stores/apiStore", () => {
+  const postMock = jest.fn(() => Promise.resolve({ data: {} }));
+  const getMock = jest.fn(() => Promise.resolve({ data: {} }));
+  return {
+    useApiStore: () => ({ post: postMock, get: getMock }),
+    postMock,
+    getMock,
+  };
+});
+import { postMock } from "stores/apiStore";
+
+describe("chatStore requests", () => {
+  let store;
+  let auth;
+  let ws;
+
+  beforeEach(() => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    store = useChatStore();
+    auth = useAuthStore();
+    auth.uid = "me";
+    Notify.create = jest.fn();
+    ws = { send: jest.fn() };
+    global.WebSocket = jest.fn(() => ws);
+    store.openSocket();
+  });
+
+  it("stores chat requests without duplicates", () => {
+    ws.onmessage({ data: JSON.stringify({ event: "chat_request", from: "u1" }) });
+    expect(store.requests).toEqual(["u1"]);
+    ws.onmessage({ data: JSON.stringify({ event: "chat_request", from: "u1" }) });
+    expect(store.requests).toEqual(["u1"]);
+  });
+
+  it("acceptRequest posts and clears entry", async () => {
+    store.requests.push("u1");
+    await store.acceptRequest("u1");
+    expect(postMock).toHaveBeenCalledWith("/friend/accept", { uid: "me", friend_uid: "u1" });
+    expect(store.requests).toEqual([]);
+  });
+
+  it("declineRequest posts and clears entry", async () => {
+    store.requests.push("u2");
+    await store.declineRequest("u2");
+    expect(postMock).toHaveBeenCalledWith("/friend/decline", { uid: "me", friend_uid: "u2" });
+    expect(store.requests).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- handle chat request queue in frontend store
- list pending requests in new `ChatRequests` component
- allow accepting or declining chat requests
- support decline endpoint in backend
- extend backend tests
- add frontend unit test for chatStore

## Testing
- `npm run test:unit` *(fails: Jest worker encountered 4 child process exceptions)*
- `PYTHONPATH=. pytest backend/tests` *(pass: 5 tests in 321.55s)*

------
https://chatgpt.com/codex/tasks/task_e_6877c22b826c832290faef58162e8ac4