### PR TITLE
Add friend status updates

### DIFF
--- a/frontend/src/components/ChatList.vue
+++ b/frontend/src/components/ChatList.vue
@@ -6,7 +6,32 @@
       label="Friend"
       input-class="text-white"
       label-color="grey-7"
-    />
+    >
+      <template #option="scope">
+        <q-item v-bind="scope.itemProps">
+          <q-item-section avatar>
+            <q-icon
+              name="circle"
+              :color="scope.opt.online ? 'positive' : 'grey-6'"
+              size="8px"
+            />
+          </q-item-section>
+          <q-item-section>{{ scope.opt.label }}</q-item-section>
+        </q-item>
+      </template>
+      <template #selected-item="scope">
+        <q-item v-bind="scope.itemProps">
+          <q-item-section avatar>
+            <q-icon
+              name="circle"
+              :color="scope.opt.online ? 'positive' : 'grey-6'"
+              size="8px"
+            />
+          </q-item-section>
+          <q-item-section>{{ scope.opt.label }}</q-item-section>
+        </q-item>
+      </template>
+    </q-select>
   </div>
 </template>
 
@@ -26,6 +51,6 @@ const model = computed({
 });
 
 const options = computed(() =>
-  props.friends.map((f) => ({ label: f.name, value: f.uid }))
+  props.friends.map((f) => ({ label: f.name, value: f.uid, online: f.online }))
 );
 </script>


### PR DESCRIPTION
## Summary
- notify original requester when a friend request is accepted
- broadcast user status on websocket connect/disconnect
- handle status updates and accept notifications in chat store
- show online indicator in chat list
- test new websocket events

## Testing
- `npx prettier --write src/components/ChatList.vue src/stores/chatStore.js`
- `npm run lint`
- `PYTHONPATH=. pytest backend/tests/test_server.py::test_friend_accept_notify -q`
- `PYTHONPATH=. pytest backend/tests/test_server.py::test_status_updates -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f644dbd48322891a27d2e8ef6457