### PR TITLE
Improve chat page visibility

### DIFF
--- a/frontend/src/components/ChatInvite.vue
+++ b/frontend/src/components/ChatInvite.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="row q-gutter-sm items-end">
-    <q-select
+  <div class="chat-section row q-gutter-sm items-end">
+    <q-input
       v-model="uid"
-      :options="options"
       label="Friend UID"
       input-class="text-white"
       label-color="grey-7"
+      outlined
     />
     <q-btn label="Send" color="primary" @click="sendRequest" />
     <q-btn label="Accept" color="primary" @click="acceptRequest" />
@@ -13,7 +13,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from "vue";
+import { ref } from "vue";
 import { useQuasar } from "quasar";
 import { useChatStore } from "stores/chatStore";
 
@@ -22,10 +22,6 @@ const emit = defineEmits(["added"]);
 const uid = ref("");
 const $q = useQuasar();
 const chat = useChatStore();
-
-const options = computed(() =>
-  chat.friends.map((f) => ({ label: f.name, value: f.uid }))
-);
 
 async function handle(action) {
   if (!uid.value) return;

--- a/frontend/src/components/ChatList.vue
+++ b/frontend/src/components/ChatList.vue
@@ -1,11 +1,13 @@
 <template>
-  <div class="column q-gutter-sm items-center" style="max-width: 300px">
+  <div class="chat-section column q-gutter-sm items-center">
     <q-select
       v-model="model"
       :options="options"
       label="Friend"
       input-class="text-white"
       label-color="grey-7"
+      dark
+      outlined
     >
       <template #option="scope">
         <q-item v-bind="scope.itemProps">
@@ -51,6 +53,6 @@ const model = computed({
 });
 
 const options = computed(() =>
-  props.friends.map((f) => ({ label: f.name, value: f.uid, online: f.online }))
+  props.friends.map((f) => ({ label: f.name, value: f.uid, online: f.online })),
 );
 </script>

--- a/frontend/src/components/ChatRequests.vue
+++ b/frontend/src/components/ChatRequests.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="requests.length" class="column q-gutter-sm">
+  <div v-if="requests.length" class="chat-section column q-gutter-sm">
     <div
       v-for="uid in requests"
       :key="uid"

--- a/frontend/src/components/ChatWindow.vue
+++ b/frontend/src/components/ChatWindow.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="friend" class="q-mt-md">
+  <div v-if="friend" class="chat-section q-mt-md">
     <div class="text-h6 text-white q-mb-sm">{{ friend.name }}</div>
     <div
       ref="container"
@@ -27,6 +27,7 @@
           label="Message"
           input-class="text-white"
           label-color="grey-7"
+          outlined
         />
         <q-btn icon="send" type="submit" color="primary" />
       </q-form>

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -113,3 +113,12 @@ body {
     border-radius: 10px;
   }
 }
+
+.chat-section {
+  background-color: #2a2a2a;
+  border: 1px solid $decent;
+  border-radius: 4px;
+  padding: 12px;
+  width: 100%;
+  max-width: 350px;
+}

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-page class="column items-center q-pa-md">
+  <q-page class="column items-center q-gutter-md q-pa-md">
     <chat-invite class="q-mb-md" @added="onInvite" />
     <chat-requests class="q-mb-md" />
     <chat-list v-model="friend" :friends="friends" />
@@ -26,7 +26,7 @@ const chat = useChatStore();
 const { friend, friends, messages, connected } = storeToRefs(chat);
 
 const currentFriend = computed(() =>
-  friends.value.find((f) => f.uid === friend.value)
+  friends.value.find((f) => f.uid === friend.value),
 );
 
 onMounted(async () => {


### PR DESCRIPTION
## Summary
- add `.chat-section` style for dark backgrounds
- restyle ChatInvite with input field and borders
- restyle ChatRequests list and ChatList select
- restyle ChatWindow input
- add spacing on ChatPage

## Testing
- `npm --prefix frontend run lint`
- `PYTHONPATH=. pytest backend/tests`
- `npm --prefix frontend run test:unit` *(fails: Jest worker encountered errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878bfb64b988322830c5222ea3dfd54