### PR TITLE
Fix chat list selection

### DIFF
--- a/frontend/src/components/ChatList.vue
+++ b/frontend/src/components/ChatList.vue
@@ -8,6 +8,8 @@
       label-color="grey-7"
       dark
       outlined
+      emit-value
+      map-options
     >
       <template #option="scope">
         <q-item v-bind="scope.itemProps">
@@ -53,6 +55,6 @@ const model = computed({
 });
 
 const options = computed(() =>
-  props.friends.map((f) => ({ label: f.name, value: f.uid, online: f.online })),
+  props.friends.map((f) => ({ label: f.name, value: f.uid, online: f.online }))
 );
 </script>


### PR DESCRIPTION
## Summary
- prevent object emission from ChatList `q-select`

## Testing
- `npx prettier src/components/ChatList.vue --write`
- `npm run lint`
- `npm run test:unit` *(fails: chatStore, LoginPage, ProgramTimer, QuickTimer, UserStatusPage)*
- `PYTHONPATH=. pytest backend/tests` *(interrupted after ~16m with 7 tests passing)*

------
https://chatgpt.com/codex/tasks/task_e_6878c64a75588322b39d58493b0b85d2