### PR TITLE
Fix duplicate chat messages

### DIFF
--- a/frontend/src/stores/chatStore.js
+++ b/frontend/src/stores/chatStore.js
@@ -128,7 +128,7 @@ export const useChatStore = defineStore("chat", {
           }
         }
         this.histories[fid] = merged;
-        if (this.friend === fid) this.messages = merged;
+        if (this.friend === fid) this.messages = [...merged];
       } catch (err) {
         this.histories[fid] = [];
       }


### PR DESCRIPTION
## Summary
- avoid aliasing chat history array when fetching messages

## Testing
- `npm run test:unit` *(fails: Cannot read properties of undefined (reading 'you'))*
- `PYTHONPATH=. pytest backend/tests` *(fails due to KeyboardInterrupt but shows 7 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6878e64a85488322ba0efdbdf02b4a6b