### PR TITLE
Update chat friend request handling

### DIFF
--- a/frontend/src/components/ChatList.vue
+++ b/frontend/src/components/ChatList.vue
@@ -64,7 +64,11 @@ const model = computed({
 });
 
 const options = computed(() =>
-  props.friends.map((f) => ({ label: f.name, value: f.uid, online: f.online })),
+  props.friends.map((f) => ({
+    label: f.pending ? `${f.name} (pending)` : f.name,
+    value: f.uid,
+    online: f.online,
+  })),
 );
 
 const chat = useChatStore();

--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -42,9 +42,6 @@ const send = (msg) => {
 };
 
 const onInvite = async (uid) => {
-  if (!friends.value.some((f) => f.uid === uid)) {
-    friends.value.push({ uid, name: uid });
-  }
   friend.value = uid;
   await chat.fetchHistory(uid);
 };

--- a/frontend/test/jest/__tests__/ChatPage.spec.js
+++ b/frontend/test/jest/__tests__/ChatPage.spec.js
@@ -42,16 +42,16 @@ describe("ChatPage", () => {
     wsMock.onopen();
     wrapper.vm.friend = "you";
     wsMock.onmessage({ data: JSON.stringify({ from: "you", message: "hi" }) });
-    expect(wrapper.vm.histories["you"][0].text).toBe("hi");
+    expect(store.histories["you"][0].text).toBe("hi");
   });
 
   it("send forwards message over websocket", async () => {
     wrapper.vm.friend = "you";
-    await wrapper.vm.connect();
+    await store.connect();
     wrapper.vm.text = "hello";
     wrapper.vm.send();
     expect(wsMock.send).toHaveBeenCalledWith(
-      JSON.stringify({ to: "you", message: "hello" })
+      JSON.stringify({ to: "you", message: "hello" }),
     );
     expect(wrapper.vm.text).toBe("");
   });
@@ -59,7 +59,7 @@ describe("ChatPage", () => {
   it("shows error notify when api fails", async () => {
     store.sendFriendRequest.mockRejectedValue(new Error("boom"));
     wrapper.vm.friend = "you";
-    await wrapper.vm.connect();
+    await store.connect();
     expect(notifyMock).toHaveBeenCalledWith({
       type: "negative",
       message: "boom",

--- a/frontend/test/jest/__tests__/chatStore.spec.js
+++ b/frontend/test/jest/__tests__/chatStore.spec.js
@@ -67,7 +67,9 @@ describe("chatStore requests", () => {
     getMock.mockResolvedValueOnce({ data: { friends: ["f1"], requests: [] } });
     getMock.mockResolvedValueOnce({ data: { username: "Bob" } });
     await store.connect();
-    expect(store.friends).toEqual([{ uid: "f1", name: "Bob", online: false }]);
+    expect(store.friends).toEqual([
+      { uid: "f1", name: "Bob", online: false, pending: false },
+    ]);
   });
 
   it("filters duplicate messages when fetching history", async () => {


### PR DESCRIPTION
## Summary
- fetch friend username and set pending flag when sending a request
- show `(pending)` label for outgoing requests in ChatList
- update ChatPage invite handler to rely on store
- adjust tests for new pending state

## Testing
- `npx prettier -w frontend/src/components/ChatList.vue frontend/src/pages/ChatPage.vue frontend/src/stores/chatStore.js frontend/test/jest/__tests__/ChatPage.spec.js frontend/test/jest/__tests__/chatStore.spec.js`
- `npm run lint`
- `npm run test:unit` *(fails: UserStatusPage test errors)*
- `PYTHONPATH=. pytest backend/tests` *(8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687907273ed88322a500bf8706905523